### PR TITLE
Make multipath_component claim devices

### DIFF
--- a/src/include/base/util.h
+++ b/src/include/base/util.h
@@ -27,6 +27,7 @@
 #include <sys/timerfd.h>
 #include <sys/types.h>
 #include <uuid/uuid.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,6 +74,11 @@ char *util_uuid_gen_str(char *buf, size_t buf_len);
  * Environment-related utilities.
  */
 int util_env_get_ull(const char *key, unsigned long long min, unsigned long long max, unsigned long long *val);
+
+/*
+ * Kernel cmdline-related utilities.
+ */
+bool util_cmdline_get_arg(const char *arg, char **value, int *ret_code);
 
 #ifdef __cplusplus
 }

--- a/src/include/resource/ubridge-cmd-module.h
+++ b/src/include/resource/ubridge-cmd-module.h
@@ -118,6 +118,7 @@ void *sid_ubridge_cmd_set_kv(struct sid_ubridge_cmd_context *cmd, sid_ubridge_cm
 			     const char *key, const void *value, size_t value_size, sid_ubridge_kv_flags_t flags);
 const void *sid_ubridge_cmd_get_kv(struct sid_ubridge_cmd_context *cmd, sid_ubridge_cmd_kv_namespace_t ns,
 				   const char *key, size_t *value_size, sid_ubridge_kv_flags_t *flags);
+const void *sid_ubridge_cmd_part_get_disk_kv(struct sid_ubridge_cmd_context *cmd, const char *key, size_t *value_size, sid_ubridge_kv_flags_t *flags);
 
 int sid_ubridge_cmd_mod_reserve_kv(struct sid_module *mod, struct sid_ubridge_cmd_mod_context *cmd_mod,
 				  sid_ubridge_cmd_kv_namespace_t ns, const char *key);

--- a/src/modules/ubridge-cmd/block/multipath_component/multipath_component.c
+++ b/src/modules/ubridge-cmd/block/multipath_component/multipath_component.c
@@ -21,14 +21,41 @@
 #include "resource/ubridge-cmd-module.h"
 
 #include <limits.h>
+#include <libudev.h>
 #include <mpath_valid.h>
 #include <stdio.h>
 
 #define ID "multipath_component"
+#define KEY "DM_MULTIPATH_DEVICE_PATH"
+struct udev *udev;
+int logsink = -1;
+
+struct config *get_multipath_config(void)
+{
+	return mpathvalid_conf;
+}
+
+void put_multipath_config(__attribute__((unused))void *conf)
+{
+	/* Noop */
+}
 
 static int _multipath_component_init(struct sid_module *module, struct sid_ubridge_cmd_mod_context *cmd_mod)
 {
 	log_debug(ID, "init");
+	/* TODO - set up dm/udev logging */
+	udev = udev_new();
+	if (!udev) {
+		log_error(ID, "failed to allocate udev context");
+		return -1;
+	}
+	if (sid_ubridge_cmd_mod_reserve_kv(module, cmd_mod, KV_NS_UDEV,
+	                                   KEY) < 0) {
+		log_error(ID, "Failed to reserve multipath udev key %s", KEY);
+		udev_unref(udev);
+		udev = NULL;
+		return -1;
+	}
 	return 0;
 }
 SID_UBRIDGE_CMD_MOD_INIT(_multipath_component_init)
@@ -36,6 +63,9 @@ SID_UBRIDGE_CMD_MOD_INIT(_multipath_component_init)
 static int _multipath_component_exit(struct sid_module *module, struct sid_ubridge_cmd_mod_context *cmd_mod)
 {
 	log_debug(ID, "exit");
+	// Do we need to unreserve the key here?
+	udev_unref(udev);
+	udev = NULL;
 	return 0;
 }
 SID_UBRIDGE_CMD_MOD_EXIT(_multipath_component_exit)
@@ -49,14 +79,27 @@ SID_UBRIDGE_CMD_MOD_RELOAD(_multipath_component_reload)
 
 static int _multipath_component_scan_pre(struct sid_module *module, struct sid_ubridge_cmd_context *cmd)
 {
+	int r;
 	log_debug(ID, "scan-pre");
 
-	if (mpath_is_path(sid_ubridge_cmd_dev_get_name(cmd), MPATH_DEFAULT,
-	                  NULL, NULL, 0)) {
-		// mark with appropriate key=value pair
+	if (mpathvalid_init(-1) < 0) {
+		log_error(ID, "failed to initialize mpathvalid");
+		return -1;
 	}
-
-	return 0;
+	// currently treats MPATH_SMART like MPATH_STRICT
+	r = mpathvalid_is_path(sid_ubridge_cmd_dev_get_name(cmd), MPATH_DEFAULT,
+	                       NULL, NULL, 0);
+	log_debug(ID, "mpathvalid_is_path returned %d", r);
+	if (r == MPATH_IS_VALID || r == MPATH_IS_VALID_NO_CHECK) {
+		sid_ubridge_cmd_set_kv(cmd, KV_NS_UDEV, KEY, "1", 2,
+		                       KV_MOD_PROTECTED);
+		// mark with appropriate key=value pair
+	} else if (r != MPATH_IS_ERROR) {
+		sid_ubridge_cmd_set_kv(cmd, KV_NS_UDEV, KEY, "0", 2,
+		                       KV_MOD_PROTECTED);
+	}
+	mpathvalid_exit();
+	return (r != MPATH_IS_ERROR);
 }
 SID_UBRIDGE_CMD_SCAN_PRE(_multipath_component_scan_pre)
 

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -906,25 +906,15 @@ void *sid_ubridge_cmd_set_kv(struct sid_ubridge_cmd_context *cmd, sid_ubridge_cm
 	return _do_sid_ubridge_cmd_set_kv(cmd, ns, KV_KEY_DOM_USER, key, flags, value, value_size);
 }
 
-static const void *_do_sid_ubridge_cmd_get_kv(struct sid_ubridge_cmd_context *cmd, sid_ubridge_cmd_kv_namespace_t ns,
-                                              const char *key, size_t *value_size, sid_ubridge_kv_flags_t *flags)
+static const void *_cmd_get_key_spec_value(struct sid_ubridge_cmd_context *cmd, struct kv_key_spec *key_spec, size_t *value_size, sid_ubridge_kv_flags_t *flags)
 {
 	const char *owner = _res_get_mod_name(cmd->mod_res);
 	const char *full_key = NULL;
 	struct kv_value *kv_value;
 	size_t size, data_offset;
-	struct kv_key_spec key_spec = {
-		.op = KV_OP_SET,
-		.ns = ns,
-		.ns_part = _get_ns_part(cmd, ns),
-		.dom = KV_KEY_DOM_USER,
-		.id = ID_NULL,
-		.id_part = ID_NULL,
-		.key = key
-	};
 	void *ret = NULL;
 
-	if (!(full_key = _buffer_compose_key(cmd->gen_buf, &key_spec)))
+	if (!(full_key = _buffer_compose_key(cmd->gen_buf, key_spec)))
 		goto out;
 
 	if (!(kv_value = kv_store_get_value(cmd->kv_store_res, full_key, &size, NULL)))
@@ -950,6 +940,20 @@ out:
 	if (full_key)
 		buffer_rewind_mem(cmd->gen_buf, full_key);
 	return ret;
+}
+
+static const void *_do_sid_ubridge_cmd_get_kv(struct sid_ubridge_cmd_context *cmd, sid_ubridge_cmd_kv_namespace_t ns, const char *key, size_t *value_size, sid_ubridge_kv_flags_t *flags)
+{
+	struct kv_key_spec key_spec = {
+		.op = KV_OP_SET,
+		.ns = ns,
+		.ns_part = _get_ns_part(cmd, ns),
+		.dom = KV_KEY_DOM_USER,
+		.id = ID_NULL,
+		.id_part = ID_NULL,
+		.key = key
+	};
+	return _cmd_get_key_spec_value(cmd, &key_spec, value_size, flags);
 }
 
 const void *sid_ubridge_cmd_get_kv(struct sid_ubridge_cmd_context *cmd, sid_ubridge_cmd_kv_namespace_t ns,

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -1870,6 +1870,30 @@ int _part_get_whole_disk(struct sid_ubridge_cmd_context *cmd,
 	return 0;
 }
 
+const void *sid_ubridge_cmd_part_get_disk_kv(struct sid_ubridge_cmd_context *cmd, const char *key, size_t *value_size, sid_ubridge_kv_flags_t *flags)
+{
+	char devno_buf[16];
+	struct kv_key_spec key_spec = {
+		.op = KV_OP_SET,
+		.ns = KV_NS_DEVICE,
+		.ns_part = ID_NULL, /* will be calculated later */
+		.dom = KV_KEY_DOM_USER,
+		.id = ID_NULL,
+		.id_part = ID_NULL,
+		.key = key
+	};
+
+	if (!cmd || !key || !*key || (key[0] == KEY_SYS_C[0]))
+		return NULL;
+
+	if (_part_get_whole_disk(cmd, cmd->mod_res, devno_buf,
+	                         sizeof(devno_buf)) < 0)
+		return NULL;
+	key_spec.ns_part = devno_buf;
+
+	return _cmd_get_key_spec_value(cmd, &key_spec, value_size, flags);
+}
+
 static int _init_delta_buffer(struct buffer **delta_buf, size_t size, struct iovec *header, size_t header_size)
 {
 	struct buffer *buf = NULL;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,12 +14,14 @@ test_kv_store_LDADD = \
 	$(top_builddir)/src/resource/libsidresource.la -lcmocka
 test_notify_SOURCES = test_notify.c
 test_notify_LDFLAGS = -Wl,--wrap=sd_notify -Wl,--wrap=buffer_get_data
-test_notify_LDADD = $(top_builddir)/src/iface/libsidiface.la -lcmocka
+test_notify_LDADD = \
+	$(top_builddir)/src/iface/libsidiface_servicelink.la -lcmocka
 test_bitmap_SOURCES = test_bitmap.c
 test_bitmap_LDADD = $(top_builddir)/src/base/libsidbase.la -lcmocka
 test_usid_SOURCES = test_usid.c
 test_usid_LDFLAGS = -Wl,--wrap=getenv
 test_usid_LDADD = \
-	$(top_builddir)/src/iface/libsidiface.la \
+	$(top_builddir)/src/log/libsidlog.la \
+	$(top_builddir)/src/iface/libsidiface_usid.la \
 	$(top_builddir)/src/base/libsidbase.la -lcmocka
 endif # HAVE_CMOCKA

--- a/tests/test_bitmap.c
+++ b/tests/test_bitmap.c
@@ -3,18 +3,20 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
-#include <bitmap.h>
+#include <base/bitmap.h>
+#include <errno.h>
 
 static void test_invert_bitmap(void **state)
 {
-	int i;
-	struct bitmap *bitmap = bitmap_create(32, true);
+	int i, ret;
+	struct bitmap *bitmap = bitmap_create(32, true, &ret);
 	assert_non_null(bitmap);
+	assert_int_equal(ret, 0);
 	assert_int_equal(bitmap_get_bit_count(bitmap),
 	                 bitmap_get_bit_set_count(bitmap));
 	for (i = 0; i < 32; i++)
 		assert_int_equal(bitmap_bit_unset(bitmap, i), 0);
-	assert_int_equal(bitmap_bit_unset(bitmap, 32), -1);
+	assert_int_equal(bitmap_bit_unset(bitmap, 32), -ERANGE);
 	assert_int_equal(bitmap_get_bit_set_count(bitmap), 0);
 }
 

--- a/tests/test_buffer.c
+++ b/tests/test_buffer.c
@@ -3,7 +3,7 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
-#include "buffer.h"
+#include "base/buffer.h"
 
 #define TEST_STR "foo"
 #define TEST_SIZE sizeof(TEST_STR)
@@ -18,7 +18,7 @@ int test_fmt_add(int buf_size)
 	struct buffer *buf = NULL;
 	char *data;
 	size_t data_size;
-	buf = buffer_create(BUFFER_TYPE_LINEAR, BUFFER_MODE_PLAIN, buf_size, 1, NULL);
+	buf = buffer_create(BUFFER_TYPE_LINEAR, BUFFER_MODE_PLAIN, buf_size, 1, 0, NULL);
 	assert_non_null(buf);
 	assert_non_null(buffer_fmt_add(buf, NULL, TEST_STR));
 	assert_int_equal(buffer_get_data(buf, (const void **)&data, &data_size),			 0);
@@ -54,7 +54,7 @@ static void test_linear_rewind_mem(void **state)
 {
 	struct buffer *buf;
 
-	buf = buffer_create(BUFFER_TYPE_LINEAR, BUFFER_MODE_PLAIN, 0, 1, NULL);
+	buf = buffer_create(BUFFER_TYPE_LINEAR, BUFFER_MODE_PLAIN, 0, 1, 0, NULL);
 	do_rewind_test(buf);
 	buffer_destroy(buf);
 }
@@ -63,7 +63,7 @@ static void test_vector_rewind_mem(void **state)
 {
 	struct buffer *buf;
 
-	buf = buffer_create(BUFFER_TYPE_VECTOR, BUFFER_MODE_PLAIN, 0, 1, NULL);
+	buf = buffer_create(BUFFER_TYPE_VECTOR, BUFFER_MODE_PLAIN, 0, 1, 0, NULL);
 	do_rewind_test(buf);
 	buffer_destroy(buf);
 }
@@ -84,7 +84,7 @@ static void test_linear_zero_add(void **state)
 {
 	struct buffer *buf;
 
-	buf = buffer_create(BUFFER_TYPE_LINEAR, BUFFER_MODE_PLAIN, 0, 1, NULL);
+	buf = buffer_create(BUFFER_TYPE_LINEAR, BUFFER_MODE_PLAIN, 0, 1, 0, NULL);
 	do_test_zero_add(buf);
 }
 
@@ -92,7 +92,7 @@ static void test_vector_zero_add(void **state)
 {
 	struct buffer *buf;
 
-	buf = buffer_create(BUFFER_TYPE_VECTOR, BUFFER_MODE_PLAIN, 0, 1, NULL);
+	buf = buffer_create(BUFFER_TYPE_VECTOR, BUFFER_MODE_PLAIN, 0, 1, 0, NULL);
 	do_test_zero_add(buf);
 }
 

--- a/tests/test_kv_store.c
+++ b/tests/test_kv_store.c
@@ -17,7 +17,7 @@ static void test_type_G(void **state)
 	struct kv_store_value *value = _create_kv_store_value(test_iov, size,
 	                                                      KV_STORE_VALUE_REF | KV_STORE_VALUE_VECTOR, 0);
 	assert_ptr_not_equal(value, NULL);
-	assert_ptr_equal(value->data_p, test_iov);
+	assert_ptr_equal(_get_ptr(value->data), test_iov);
 	assert_int_equal(value->size, size);
 	assert_int_equal(value->int_flags, 0);
 	assert_int_equal(value->ext_flags,
@@ -41,7 +41,7 @@ static void test_type_H(void **state)
 	                               KV_STORE_VALUE_REF | KV_STORE_VALUE_VECTOR,
 	                               KV_STORE_VALUE_OP_MERGE);
 	assert_ptr_not_equal(value, NULL);
-	assert_ptr_equal(value->data_p, test_iov);
+	assert_ptr_equal(_get_ptr(value->data), test_iov);
 	assert_int_equal(value->size, size);
 	for (i = 0; i < size; i++)
 		assert_ptr_not_equal(test_iov[i].iov_base,

--- a/tests/test_notify.c
+++ b/tests/test_notify.c
@@ -4,7 +4,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <systemd/sd-daemon.h>
-#include "../src/iface/service-link-iface.c"
+#include "../src/iface/service-link.c"
 
 int __wrap_sd_notify(int unset_environment, const char *state)
 {

--- a/tests/test_usid.c
+++ b/tests/test_usid.c
@@ -32,7 +32,7 @@ static void test_checkpoint_env(void **state)
 		.argv = test_argv
 	};
 
-	buf = buffer_create(BUFFER_TYPE_LINEAR, BUFFER_MODE_SIZE_PREFIX, 0, 1, NULL);
+	buf = buffer_create(BUFFER_TYPE_LINEAR, BUFFER_MODE_SIZE_PREFIX, 0, 1, 0, NULL);
 	assert_non_null(buf);
 	will_return(__wrap_getenv, "8");
 	will_return(__wrap_getenv, "0");

--- a/udev/00-sid.rules.in
+++ b/udev/00-sid.rules.in
@@ -1,1 +1,1 @@
-SUBSYSTEM=="block", ACTION=="change|remove", IMPORT{program}="(SBINDIR)/usid scan"
+SUBSYSTEM=="block", ACTION=="add|change|remove", IMPORT{program}="(SBINDIR)/usid scan"


### PR DESCRIPTION
This updates the multipath component code to set the udev property to claim multipath devices.  It also updates the udev rules to make call usid on add events, and makes the multipath component respect the kernel cmdline multipath settings.