### PR TITLE
base: hash: fix lost hash_node because of _kv_delta

### DIFF
--- a/src/base/hash.c
+++ b/src/base/hash.c
@@ -170,6 +170,10 @@ static int _do_hash_insert_binary(struct hash_table *t, struct hash_node **c, co
 	if (!n)
 		return -1;
 
+	/* A hash_update_fn may have added another hash node to this slot */
+	while (*c != NULL)
+		c = &((*c)->next);
+
 	n->data = data;
 	n->next = 0;
 	*c = n;
@@ -406,6 +410,10 @@ int hash_update_binary(struct hash_table *t, const void *key, uint32_t len, void
 {
 	struct hash_node **c = _find(t, key, len);
 
+	/*
+	 * the hash_update_fn may add nodes to the hash table, but it must not
+	 * add this key to the hash table or remove any nodes.
+	 */
 	if (*c) {
 		if (!hash_update_fn || hash_update_fn(key, len, (*c)->data, data, hash_update_fn_arg))
 			(*c)->data = data ? *data : NULL;


### PR DESCRIPTION
When adding a new hash_node, hash_update_binary() finds the pointer that
will be set to point to that hash_node before calling _hash_update_fn(),
which calls the kv_update_fn. _kv_delta() can itself add hash_nodes to
the hash_table.  If these nodes are in the same slot as the one in the
original call to hash_update_binary(), they will set the same pointer
that was found in the original call. This means that when the original
hash_node is added, it will overwrite the pointer to the hash_nodes
added by _kv_delta() causing them to be lost, and memory to leak.

To fix this, _do_hash_insert_binary() now checks if the found pointer is
no longer NULL after the kv_update_fn is called, and if so, continues
down the list until if finds a NULL pointer. This will fix the issue,
assuming that the kv_update_fn never adds the original key to the hash
table, and that it never deletes any node from the hash table.