### PR TITLE
Add option to output logs as structured data to the journal

### DIFF
--- a/man/sid.8.in
+++ b/man/sid.8.in
@@ -55,6 +55,9 @@ Run in foreground.
 .BR \-h ", " \-\-help
 Display the help text.
 .TP
+.BR \-j ", " \-\-journal
+Log to the journal.
+.TP
 .BR \-v ", " \-\-verbose
 Run in verbose mode. Repeat up to 4 times to increase the level of detail
 of log messages.

--- a/src/include/log/log.h
+++ b/src/include/log/log.h
@@ -33,6 +33,7 @@ typedef enum {
 	LOG_TARGET_NONE,
 	LOG_TARGET_STANDARD,
 	LOG_TARGET_SYSLOG,
+	LOG_TARGET_JOURNAL,
 	_LOG_TARGET_COUNT
 } log_target_t;
 
@@ -53,6 +54,7 @@ struct log_target {
 
 extern const struct log_target log_target_standard;
 extern const struct log_target log_target_syslog;
+extern const struct log_target log_target_journal;
 
 void log_init(log_target_t target, int verbose_mode);
 void log_change_target(log_target_t new_target);

--- a/src/log/Makefile.am
+++ b/src/log/Makefile.am
@@ -21,11 +21,14 @@ pkglib_LTLIBRARIES = libsidlog.la
 
 libsidlog_la_SOURCES = log-target-standard.c \
 		       log-target-syslog.c \
+		       log-target-journal.c \
 		       log.c
 
 logdir = $(pkgincludedir)/log
 
 log_HEADERS = $(top_builddir)/src/include/log/log.h
+
+libsidlog_la_LIBADD = $(SYSTEMD_LIBS)
 
 libsidlog_la_LDFLAGS = -version-info 0:0:0
 

--- a/src/log/log-target-journal.c
+++ b/src/log/log-target-journal.c
@@ -1,0 +1,135 @@
+/*
+ * This file is part of SID.
+ *
+ * Copyright (C) 2017-2018 Red Hat, Inc. All rights reserved.
+ *
+ * SID is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * SID is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with SID.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "log/log.h"
+#include "base/buffer.h"
+
+#include <systemd/sd-journal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#define BUFFER_SIZE 4096
+
+static int _max_level_id = -1;
+static int _force_err_out = 0;
+static int _with_pids = 0;
+static int _with_src_info = 1;
+
+void log_journal_open(int verbose_mode)
+{
+	switch (verbose_mode) {
+		case 0:
+			_max_level_id = LOG_NOTICE;
+			break;
+		case 1:
+			_max_level_id = LOG_INFO;
+			break;
+		case 2:
+			_max_level_id = LOG_DEBUG;
+			break;
+		case 3:
+			_max_level_id = LOG_DEBUG;
+			_with_src_info = 1;
+			_force_err_out = 1;
+			break;
+		default:
+			_max_level_id = LOG_DEBUG;
+			_with_src_info = 1;
+			_force_err_out = 1;
+			_with_pids = 1;
+			break;
+	}
+}
+
+void log_journal_close(void)
+{
+	fflush(stdout);
+	fflush(stderr);
+}
+
+void log_journal_output(int level_id,
+                        const char *prefix,
+                        int class_id,
+                        int errno_id,
+                        const char *src_file_name,
+                        int src_line_number,
+                        const char *function_name,
+                        const char *format,
+                        va_list ap)
+{
+	char msg[4096];
+	size_t prefix_len, remaining_len;
+	int r;
+
+	if (level_id > _max_level_id)
+		return;
+
+	/* +1 for '<', +1 for '>' and +1 for '\0' at the end */
+	prefix_len = strlen(prefix) + 3;
+
+	if (prefix_len >= sizeof(msg)) {
+		sd_journal_send(
+		    "MESSAGE=%s: (log prefix too long)",
+		    "PRIORITY=%d", level_id,
+		    "CODE_FILE=%s", src_file_name,
+		    "CODE_LINE=%d", src_line_number,
+		    "CODE_FUNC=%s", function_name,
+		    NULL);
+
+		return;
+	}
+
+	remaining_len = sizeof(msg) - prefix_len;
+
+	(void) snprintf(msg, sizeof(msg), "<%s> ", prefix);
+	r = vsnprintf(msg + prefix_len, remaining_len, format, ap);
+
+	if (r < 0 || r >= remaining_len)
+		sd_journal_send(
+		    "MESSAGE=%s: (log message truncated)",
+		    "PRIORITY=%d", level_id,
+		    "CODE_FILE=%s", src_file_name,
+		    "CODE_LINE=%d", src_line_number,
+		    "CODE_FUNC=%s", function_name,
+		    NULL);
+
+	if (r > 0) {
+		if (_with_src_info)
+			sd_journal_send(
+			    "MESSAGE=%s", msg,
+			    "PREFIX=%s", prefix,
+			    "PRIORITY=%d", level_id,
+			    "CODE_FILE=%s", src_file_name,
+			    "CODE_LINE=%d", src_line_number,
+			    "CODE_FUNC=%s", function_name,
+			    NULL);
+		else
+			sd_journal_print(level_id,
+			                 "MESSAGE=%s", msg,
+			                 "PREFIX=%s", prefix,
+			                 NULL);
+	}
+}
+
+const struct log_target log_target_journal = {
+	.name = "journal",
+	.open = log_journal_open,
+	.close = log_journal_close,
+	.output = log_journal_output
+};

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -24,7 +24,8 @@ static int _current_verbose_mode = 0;
 
 static const struct log_target *log_target_registry[] = {
 	[LOG_TARGET_STANDARD] = &log_target_standard,
-	[LOG_TARGET_SYSLOG] = &log_target_syslog
+	[LOG_TARGET_SYSLOG] = &log_target_syslog,
+	[LOG_TARGET_JOURNAL] = &log_target_journal
 };
 
 void log_init(log_target_t target, int verbose_mode)


### PR DESCRIPTION
This is just a "work in progress" to see if you are interested in adding logging to the journal as an option.

I think it would be useful to add structure to the device specific messages.  For example adding IDs for block devices related to storage events would make monitoring specific devices easier.

Please let me know what you think...  FYI - this is an example of a journal entry:

{
	"_SELINUX_CONTEXT" : "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023",
	"_TRANSPORT" : "journal",
	"_UID" : "0",
	"_GID" : "0",
	"_COMM" : "sid",
	"_CAP_EFFECTIVE" : "ffffffffff",
	"_BOOT_ID" : "d0a2df43b8d748daa238fb6cc495c959",
	"_SYSTEMD_CGROUP" : "/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-14054f91-f531-4340-925c-5c327c264ebb.scope",
	"_SYSTEMD_INVOCATION_ID" : "7e2b057d6b3142efb4c52712d4b61cc0",
	"_SYSTEMD_UNIT" : "user@1000.service",
	"_SYSTEMD_OWNER_UID" : "1000",
	"_SYSTEMD_USER_UNIT" : "vte-spawn-14054f91-f531-4340-925c-5c327c264ebb.scope",
	"__MONOTONIC_TIMESTAMP" : "524004221675",
	"MESSAGE" : "<module-registry/block> Failed to preload module /usr/local/lib/sid/modules/ucmd/block/blkid.so.",
	"SYSLOG_IDENTIFIER" : "sid",
	"_AUDIT_SESSION" : "6",
	"CODE_LINE" : [
		"292",
		"114"
	],
	"_MACHINE_ID" : "2fa37592ad4846309626eeb1c6e82856",
	"_SOURCE_REALTIME_TIMESTAMP" : "1607293634511491",
	"_CMDLINE" : "/usr/local/sbin/sid -f -v",
	"CODE_FILE" : [
		"log-target-journal.c",
		"module-registry.c"
	],
	"_SYSTEMD_SLICE" : "user-1000.slice",
	"PRIORITY" : "3",
	"_AUDIT_LOGINUID" : "1000",
	"_PID" : "1059155",
	"__REALTIME_TIMESTAMP" : "1607293634511517",
	"__CURSOR" : "s=af0096f0240342f98197f9723199ef17;i=6add;b=d0a2df43b8d748daa238fb6cc495c959;m=7a0115e2eb;t=5b5d33622829d;x=570244eabdfeaeb9",
	"CODE_FUNC" : [
		"log_journal_output",
		"_preload_modules"
	],
	"_EXE" : "/usr/local/sbin/sid",
	"_HOSTNAME" : "localhost.localdomain",
	"_SYSTEMD_USER_SLICE" : "apps-org.gnome.Terminal.slice"
}


