### PR TITLE
global: Use libelogind when libsystemd is not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,9 @@ AC_TYPE_UINT64_T
 AC_FUNC_ERROR_AT_LINE
 AC_FUNC_MALLOC
 
-PKG_CHECK_MODULES(SYSTEMD, libsystemd >= 221) # event loop supported in libsystemd version >= 221
+# event loop supported in libsystemd version >= 221
+PKG_CHECK_MODULES(SYSTEMD, libsystemd >= 221, [], [
+    PKG_CHECK_MODULES(ELOGIND, [libelogind >= 221])])
 
 PKG_CHECK_MODULES(UDEV, libudev >= 174) # support for device tagging added in libudev version >= 174
 

--- a/src/resource/Makefile.am
+++ b/src/resource/Makefile.am
@@ -34,8 +34,10 @@ pkginclude_HEADERS = $(top_builddir)/src/include/types.h \
 		     $(top_builddir)/src/include/ubridge-cmd-module.h \
 		     $(top_builddir)/src/include/worker-control.h
 libsidresource_la_CFLAGS = $(SYSTEMD_CFLAGS) \
+			   $(ELOGIND_CFLAGS) \
 			   $(UDEV_CFLAGS)
 libsidresource_la_LIBADD = $(top_builddir)/src/misc/libsidmisc.la \
 			   $(SYSTEMD_LIBS) \
+			   $(ELOGIND_LIBS) \
 			   $(UDEV_LIBS) \
 			   -ldl


### PR DESCRIPTION
Elogind ships with the libelogind library that is built upon
libsystemd sources. Symbol names, header file naming and most
of its original functionality is preserved.

https://github.com/elogind/elogind

Resolves #17 