### PR TITLE
Fix automatic formatting for #include <cmocka.h> in tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -82,6 +82,8 @@ IncludeCategories:
     Priority:        0
   - Regex:           '^"'
     Priority:        1
+  - Regex:           '^<cmocka.h>'
+    Priority:        3
   - Regex:           '.*'
     Priority:        2
 # IncludeIsMainRegex: '$'

--- a/tests/test_bitmap.c
+++ b/tests/test_bitmap.c
@@ -1,10 +1,11 @@
 #include <base/bitmap.h>
-#include <cmocka.h>
 #include <errno.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>
+
+#include <cmocka.h>
 
 static void test_invert_bitmap(void **state)
 {

--- a/tests/test_buffer.c
+++ b/tests/test_buffer.c
@@ -1,10 +1,11 @@
 #include "base/buffer.h"
 
-#include <cmocka.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>
+
+#include <cmocka.h>
 
 #define TEST_STR   "foo"
 #define TEST_SIZE  sizeof(TEST_STR)

--- a/tests/test_hash.c
+++ b/tests/test_hash.c
@@ -1,11 +1,12 @@
 #include "base/hash.h"
 
-#include <cmocka.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <cmocka.h>
 
 #define KEY_COUNT 10
 

--- a/tests/test_notify.c
+++ b/tests/test_notify.c
@@ -1,11 +1,12 @@
 #include "../src/iface/service-link.c"
 
-#include <cmocka.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <systemd/sd-daemon.h>
+
+#include <cmocka.h>
 
 int __wrap_sd_notify(int unset_environment, const char *state)
 {

--- a/tests/test_usid.c
+++ b/tests/test_usid.c
@@ -1,10 +1,11 @@
 #define _GNU_SOURCE
-#include <cmocka.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <cmocka.h>
 #define main orig_main
 #include "../src/tools/usid/usid.c"
 #undef main


### PR DESCRIPTION
`#include <cmocka.h>` in tests needs to go at the very end - looks like cmocka doesn't include its own dependencies.