### PR TITLE
sidctl: add json output for dump and version commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ libtool
 .mk.log
 
 *.swp
+
+.vscode/

--- a/src/tools/sidctl/sidctl.c
+++ b/src/tools/sidctl/sidctl.c
@@ -42,12 +42,183 @@
 #define KEY_SID_MINOR    "SID_MINOR"
 #define KEY_SID_RELEASE  "SID_RELEASE"
 
+#define PRINT_JSON_START_ARRAY "[\n"
+#define PRINT_JSON_START_ELEM  "{\n"
+#define PRINT_JSON_END_MAPS    "}\n"
+#define PRINT_JSON_END_ELEM    "},\n"
+#define PRINT_JSON_END_LAST    "}"
+#define PRINT_JSON_END_ARRAY   "]"
+#define PRINT_JSON_INDENT      "    "
+
+typedef enum
+{
+	TABLE,
+	JSON,
+} output_format_t;
+
 struct args {
 	int    argc;
 	char **argv;
 };
 
-static int _usid_cmd_dump(struct args *args)
+void print_indent(int level)
+{
+	for (int i = 0; i < level; i++) {
+		printf(PRINT_JSON_INDENT);
+	}
+}
+
+void print_start_document(output_format_t format, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf(PRINT_JSON_START_ELEM);
+	}
+}
+
+void print_end_document(output_format_t format, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("%s\n", PRINT_JSON_END_LAST);
+	}
+}
+
+void print_start_array(char *array_name, output_format_t format, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("\"%s\": %s", array_name, PRINT_JSON_START_ARRAY);
+	}
+}
+
+void print_end_array(bool needs_comma, output_format_t format, int level)
+{
+	if (format == JSON) {
+		printf("\n");
+		print_indent(level);
+		printf(PRINT_JSON_END_ARRAY);
+		if (needs_comma)
+			printf(",\n");
+		else
+			printf("\n");
+	}
+}
+
+void print_start_elem(bool needs_comma, output_format_t format, int level)
+{
+	if (format == JSON) {
+		if (needs_comma)
+			printf(",\n");
+		print_indent(level);
+		printf("%s", PRINT_JSON_START_ELEM);
+	} else {
+		printf("\n");
+	}
+}
+
+void print_end_elem(output_format_t format, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("%s", PRINT_JSON_END_LAST);
+	} else {
+		printf("\n");
+	}
+}
+
+void print_str_field(char *field_name, char *value, output_format_t format, bool trailing_comma, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("\"%s\": ", field_name);
+		printf("\"%s\"", value);
+		if (trailing_comma)
+			printf(",");
+		printf("\n");
+	} else {
+		printf("%s", field_name);
+		printf("%s", ": ");
+		printf("%s", value);
+		printf("%s", "\n");
+	}
+}
+
+void print_uint_field(char *field_name, uint value, output_format_t format, bool trailing_comma, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("\"%s\": ", field_name);
+		printf("%u", value);
+		if (trailing_comma)
+			printf(",");
+		printf("\n");
+	} else {
+		printf("%s", field_name);
+		printf("%s", ": ");
+		printf("%u", value);
+		printf("%s", "\n");
+	}
+}
+
+void print_int64_field(char *field_name, uint64_t value, output_format_t format, bool trailing_comma, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("\"%s\": ", field_name);
+		printf("%" PRIu64, value);
+		if (trailing_comma)
+			printf(",");
+		printf("\n");
+	} else {
+		printf("%s", field_name);
+		printf("%s", ": ");
+		printf("%" PRIu64, value);
+		printf("%s", "\n");
+	}
+}
+
+void print_bool_array_elem(char *field_name, bool value, output_format_t format, bool trailing_comma, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("{\"%s\": %s}", field_name, value ? "true" : "false");
+		if (trailing_comma)
+			printf(",\n");
+	} else {
+		if (value) {
+			printf("%s", field_name);
+			printf("\n");
+		}
+	}
+}
+
+void print_uint_array_elem(uint value, output_format_t format, bool trailing_comma, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("%u", value);
+		if (trailing_comma)
+			printf(",\n");
+	} else {
+		printf("%u", value);
+	}
+}
+
+void print_str_array_elem(char *value, output_format_t format, bool trailing_comma, int level)
+{
+	if (format == JSON) {
+		print_indent(level);
+		printf("\"%s\"", value);
+		if (trailing_comma)
+			printf(",\n");
+	} else {
+		printf("%s", value);
+		printf("\n");
+	}
+}
+
+static int _usid_cmd_dump(struct args *args, output_format_t format)
 {
 	struct buffer *         buf = NULL;
 	char *                  data, *ptr;
@@ -57,6 +228,7 @@ static int _usid_cmd_dump(struct args *args)
 	int                     r;
 	unsigned int            i = 0, j;
 	uint32_t                len;
+	bool                    needs_comma = false;
 
 	if ((r = usid_req(LOG_PREFIX, USID_CMD_DUMP, 0, NULL, NULL, &buf)) == 0) {
 		buffer_get_data(buf, (const void **) &msg, &size);
@@ -66,101 +238,111 @@ static int _usid_cmd_dump(struct args *args)
 		}
 		size -= USID_MSG_HEADER_SIZE;
 		ptr = data = msg->data;
-
+		print_start_document(format, 0);
+		print_start_array("siddb", format, 1);
 		while (ptr < data + size) {
 			memcpy(&hdr, ptr, sizeof(hdr));
-			if (hdr.data_count == 0) /* check for dummy entry */
+			if (hdr.data_count == 0) { /* check for dummy entry */
 				break;
+			}
+			print_start_elem(needs_comma, format, 2);
 			ptr += sizeof(hdr);
 			memcpy(&len, ptr, sizeof(len)); /* get key */
 			ptr += sizeof(len);
-			printf("--- RECORD %u\n", i);
-			printf("    key: %s\n", ptr);
+			print_uint_field("RECORD", i, format, true, 3);
+			print_str_field("key", ptr, format, true, 3);
+
 			ptr += len;
 			memcpy(&len, ptr, sizeof(len)); /* get owner */
 			ptr += sizeof(len);
-			printf("    seqnum: %" PRIu64 "  flags: %s%s%s%s  owner: %s\n",
-			       hdr.seqnum,
-			       hdr.flags & KV_PERSISTENT ? "KV_PERSISTENT " : "",
-			       hdr.flags & KV_MOD_PROTECTED ? "KV_MOD_PROTECTED " : "",
-			       hdr.flags & KV_MOD_PRIVATE ? "KV_MOD_PRIVATE " : "",
-			       hdr.flags & KV_MOD_RESERVED ? "KV_MOD_RESERVED " : "",
-			       ptr);
+
+			print_uint_field("seqnum", hdr.seqnum, format, true, 3);
+			print_start_array("flags", format, 3);
+			print_bool_array_elem("KV_PERSISTENT", hdr.flags & KV_PERSISTENT, format, true, 4);
+			print_bool_array_elem("KV_MOD_PROTECTED", hdr.flags & KV_MOD_PROTECTED, format, true, 4);
+			print_bool_array_elem("KV_MOD_PRIVATE", hdr.flags & KV_MOD_PRIVATE, format, true, 4);
+			print_bool_array_elem("KV_MOD_RESERVED", hdr.flags & KV_MOD_RESERVED, format, false, 4);
+			print_end_array(true, format, 3);
+			print_str_field("owner", ptr, format, true, 3);
+
 			ptr += len;
+			print_start_array("values", format, 3);
 			if (hdr.data_count == 1) {
 				memcpy(&len, ptr, sizeof(len));
 				ptr += sizeof(len);
 				if (len == 0)
-					printf("    value:\n");
+					print_str_array_elem("", format, false, 4);
 				else
-					printf("    value: %s\n", ptr);
+					print_str_array_elem(ptr, format, false, 4);
 				ptr += len;
 			} else {
-				printf("    value: vector\n");
 				for (j = 0; j < hdr.data_count; j++) {
 					memcpy(&len, ptr, sizeof(len));
 					ptr += sizeof(len);
 					if (len == 0)
-						printf("      [%u] =\n", j);
+						print_uint_array_elem(j, format, j + 1 < hdr.data_count, 4);
 					else
-						printf("      [%u] = %s\n", j, ptr);
+						print_str_array_elem(ptr, format, j + 1 < hdr.data_count, 4);
 					ptr += len;
 				}
 			}
+			print_end_array(false, format, 3);
 			i++;
+			print_end_elem(format, 2);
+			needs_comma = true;
 		}
+		print_end_array(false, format, 1);
+		print_end_document(format, 0);
 		buffer_destroy(buf);
 	}
 	return r;
 }
 
-static int _usid_cmd_version(struct args *args)
+static int _usid_cmd_version(struct args *args, output_format_t format)
 {
 	struct buffer *         buf = NULL;
 	struct usid_msg_header *hdr;
 	size_t                  size;
 	struct usid_version *   vsn = NULL;
 	int                     r;
+	r = usid_req(LOG_PREFIX, USID_CMD_VERSION, 0, NULL, NULL, &buf);
 
-	fprintf(stdout,
-	        KEY_SIDCTL_PROTOCOL "=%" PRIu8 "\n" KEY_SIDCTL_MAJOR "=%" PRIu16 "\n" KEY_SIDCTL_MINOR "=%" PRIu16
-	                            "\n" KEY_SIDCTL_RELEASE "=%" PRIu16 "\n",
-	        USID_PROTOCOL,
-	        SID_VERSION_MAJOR,
-	        SID_VERSION_MINOR,
-	        SID_VERSION_RELEASE);
+	print_start_document(format, 0);
 
-	if ((r = usid_req(LOG_PREFIX, USID_CMD_VERSION, 0, NULL, NULL, &buf)) == 0) {
+	print_uint_field("KEY_SIDCTL_PROTOCOL", USID_PROTOCOL, format, true, 1);
+	print_uint_field("KEY_SIDCTL_MAJOR", SID_VERSION_MAJOR, format, true, 1);
+	print_uint_field("KEY_SIDCTL_MINOR", SID_VERSION_MINOR, format, true, 1);
+	print_uint_field("KEY_SIDCTL_RELEASE", SID_VERSION_RELEASE, format, r == 0, 1);
+
+	if (r == 0) {
 		buffer_get_data(buf, (const void **) &hdr, &size);
 
 		if (size >= (USID_MSG_HEADER_SIZE + USID_VERSION_SIZE)) {
 			vsn = (struct usid_version *) hdr->data;
-			fprintf(stdout,
-			        KEY_SID_PROTOCOL "=%" PRIu8 "\n" KEY_SID_MAJOR "=%" PRIu16 "\n" KEY_SID_MINOR "=%" PRIu16
-			                         "\n" KEY_SID_RELEASE "=%" PRIu16 "\n",
-			        hdr->prot,
-			        vsn->major,
-			        vsn->minor,
-			        vsn->release);
+			print_uint_field("KEY_SID_PROTOCOL", hdr->prot, format, true, 1);
+			print_uint_field("KEY_SID_MAJOR", vsn->major, format, true, 1);
+			print_uint_field("KEY_SID_MINOR", vsn->minor, format, true, 1);
+			print_uint_field("KEY_SID_RELEASE", vsn->release, format, false, 1);
 		}
 
 		buffer_destroy(buf);
 	}
-
+	print_end_document(format, 0);
 	return r;
 }
 
 static void _help(FILE *f)
 {
 	fprintf(f,
-	        "Usage: sidctl [-h|--help] [-v|--verbose] [-V|--version] [command]\n"
+	        "Usage: sidctl [-h|--help] [-v|--verbose] [-V|--version] [-f|--format json] [command]\n"
 	        "\n"
 	        "Control and Query the SID daemon.\n"
 	        "\n"
 	        "Global options:\n"
-	        "    -h|--help       Show this help information.\n"
-	        "    -v|--verbose    Verbose mode, repeat to increase level.\n"
-	        "    -V|--version    Show USID version.\n"
+	        "    -f|--format json  Show the output in JSON.\n"
+	        "    -h|--help         Show this help information.\n"
+	        "    -v|--verbose      Verbose mode, repeat to increase level.\n"
+	        "    -V|--version      Show USID version.\n"
 	        "\n"
 	        "Commands and arguments:\n"
 	        "\n"
@@ -186,23 +368,32 @@ static void _version(FILE *f)
 
 int main(int argc, char *argv[])
 {
-	int         opt;
-	int         verbose = 0;
-	struct args subcmd_args;
-	int         r = -1;
+	int             opt;
+	int             verbose = 0;
+	struct args     subcmd_args;
+	int             r      = -1;
+	output_format_t format = TABLE;
 
 	struct option longopts[] = {
-		{"help", 0, NULL, 'h'},
-		{"verbose", 0, NULL, 'v'},
-		{"version", 0, NULL, 'V'},
-		{NULL, 0, NULL, 0},
+		{"format", required_argument, NULL, 'f'},
+		{"help", no_argument, NULL, 'h'},
+		{"verbose", no_argument, NULL, 'v'},
+		{"version", no_argument, NULL, 'V'},
+		{NULL, no_argument, NULL, 0},
 	};
 
-	while ((opt = getopt_long(argc, argv, "hvV", longopts, NULL)) != EOF) {
+	while ((opt = getopt_long(argc, argv, "f:hvV", longopts, NULL)) != EOF) {
 		switch (opt) {
 			case 'h':
 				_help(stdout);
 				return EXIT_SUCCESS;
+			case 'f':
+				if (optarg == NULL || strcmp("json", optarg) != 0) {
+					_help(stderr);
+					return EXIT_FAILURE;
+				}
+				format = JSON;
+				break;
 			case 'v':
 				verbose++;
 				break;
@@ -227,10 +418,10 @@ int main(int argc, char *argv[])
 
 	switch (usid_cmd_name_to_type(subcmd_args.argv[0])) {
 		case USID_CMD_VERSION:
-			r = _usid_cmd_version(&subcmd_args);
+			r = _usid_cmd_version(&subcmd_args, format);
 			break;
 		case USID_CMD_DUMP:
-			r = _usid_cmd_dump(&subcmd_args);
+			r = _usid_cmd_dump(&subcmd_args, format);
 			break;
 		default:
 			_help(stderr);


### PR DESCRIPTION
Note: also updated .gitignore with .vscode

The PR is the minimum to get JSON output for sidctl dump and version commands.

Example output for dump:

```
# sidctl dump -j
{
    "siddb": [
        {
            "RECORD": 0,
            "key": ":U:::::ID_FS_BOOT_SYSTEM_ID",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 1,
            "key": ":U:::::ID_FS_UUID_SUB_ENC",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 2,
            "key": ":U:::::ID_FS_LABEL_ENC",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 3,
            "key": ":U:::::ID_FS_UUID_SUB",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 4,
            "key": ":U:::::ID_PART_TABLE_UUID",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 5,
            "key": ":U:::::ID_FS_UUID_ENC",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 6,
            "key": ":U:::::ID_FS_LABEL",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 7,
            "key": ":U:::::ID_FS_VERSION",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 8,
            "key": ":U:::::ID_FS_PUBLISHER_ID",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 9,
            "key": ":U:::::ID_PART_ENTRY_NAME",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 10,
            "key": ":U:::::ID_PART_TABLE_TYPE",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 11,
            "key": ":D:::::SID_NEXT_MOD",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 12,
            "key": ":U:::::ID_FS_APPLICATION_ID",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 13,
            "key": ":U:::::ID_FS_USAGE",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 14,
            "key": ":U:::::ID_FS_UUID",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 15,
            "key": ":U:::::ID_FS_TYPE",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 16,
            "key": ":U:::::ID_FS_SYSTEM_ID",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 17,
            "key": ":U:::::ID_PART_ENTRY_TYPE",
            "seqnum": 0,
            "KV_MOD_RESERVED": true,
            "owner": "block/blkid",
            "value": ""
        },
        {
            "RECORD": 18,
            "key": ":U:(null)::::SID_SESSION_ID",
            "seqnum": 0,
            "KV_PERSISTENT": true,
            "owner": "#core",
            "value": "597e2645-90ff-45e1-a618-ace103b9b88b"
        }
    ]
}

```

Example output for version:

```
# sidctl version -j
{
    "KEY_SIDCTL_PROTOCOL": 1,
    "KEY_SIDCTL_MAJOR": 0,
    "KEY_SIDCTL_MINOR": 0,
    "KEY_SIDCTL_RELEASE": 4,
    "KEY_SID_PROTOCOL": 1,
    "KEY_SID_MAJOR": 0,
    "KEY_SID_MINOR": 0,
    "KEY_SID_RELEASE": 4
}
```