### PR TITLE
Add --coverage option to compile and link lines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,3 +148,9 @@ AC_SUBST([udevrulesdir])
 
 AC_OUTPUT
 AM_CHECK_CMOCKA
+
+AC_ARG_ENABLE([codecov],
+  [AS_HELP_STRING([--enable-codecov], [enable code covergae testing ])],,
+  [enable_codecov=yes])
+
+AM_CONDITIONAL([ENABLE_CODECOV], [test x$enable_codecov = xyes])


### PR DESCRIPTION
Allow a user to specify --enable-codecov on the configure command line
that translates to --coverage being passed to the compile and link
lines.  After sid is compiled, .gcda and .gcno files are generated.
HTML can then be generated via:

gcovr . --html-details > coverage.html
