### PR TITLE
resource: Don't create a signal event for SIGCHLD

### DIFF
--- a/src/resource/resource.c
+++ b/src/resource/resource.c
@@ -485,6 +485,7 @@ static int _sd_signal_event_handler(sd_event_source *sd_es, int sfd, uint32_t re
 	return ((sid_resource_signal_event_handler_t) es->handler)(es, &si, es->res);
 }
 
+/* This should not watch the SIGCHLD signal if sd_event_add_child() is also used */
 int sid_resource_create_signal_event_source(sid_resource_t *                    res,
                                             sid_resource_event_source_t **      es,
                                             sigset_t                            mask,
@@ -510,7 +511,7 @@ int sid_resource_create_signal_event_source(sid_resource_t *                    
 	}
 
 	if (res_event_loop->event_loop.signalfd == -1) {
-		res_event_loop->event_loop.signalfd = signalfd(-1, &mask, 0);
+		res_event_loop->event_loop.signalfd = signalfd(-1, &mask, SFD_NONBLOCK);
 		if (res_event_loop->event_loop.signalfd < 0) {
 			log_error(ID(res), "Failed to create signalfd.");
 			r = -errno;

--- a/src/resource/sid.c
+++ b/src/resource/sid.c
@@ -53,11 +53,17 @@ static int _init_sid(sid_resource_t *res, const void *kickstart_data, void **dat
 	sigset_t mask;
 
 	sigemptyset(&mask);
+	sigaddset(&mask, SIGCHLD);
+	if (sigprocmask(SIG_BLOCK, &mask, NULL) < 0) {
+		log_error(ID(res), "Failed to block SIGCHLD signal.");
+		goto fail;
+	}
+
+	sigemptyset(&mask);
 	sigaddset(&mask, SIGTERM);
 	sigaddset(&mask, SIGINT);
 	sigaddset(&mask, SIGPIPE);
 	sigaddset(&mask, SIGHUP);
-	sigaddset(&mask, SIGCHLD);
 
 	if (sid_resource_create_signal_event_source(res, NULL, mask, _on_sid_signal_event, 0, "signal_handler", NULL) < 0) {
 		log_error(ID(res), "Failed to create signal handlers.");


### PR DESCRIPTION
Signal event handling through sd_event_add_signal() has special code to
deal with the fact that sd_event_add_child() may also be watching for
the SIGCHLD signal. If SIGCHLD is watched by the new SID signal event
code, it can get stuck in _sd_signal_event_handler() when a child exits.

Don't watch for SIGCHLD, to avoid interfering with sd_event_add_child().
Also, open the signalfd in non-blocking mode, as sd_event_add_signal()
does, to avoid the possibility of getting stuck in
_sd_signal_event_handler().