### PR TITLE
kv export code merge

### DIFF
--- a/src/base/formatter.c
+++ b/src/base/formatter.c
@@ -30,10 +30,20 @@
 #define PRINT_JSON_END_ARRAY   "]"
 #define PRINT_JSON_INDENT      "    "
 
+static void _print_fmt(struct buffer *buf, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	buffer_vfmt_add(buf, NULL, fmt, ap);
+	buffer_rewind(buf, 1, BUFFER_POS_REL);
+	va_end(ap);
+}
+
 void print_indent(int level, struct buffer *buf)
 {
 	for (int i = 0; i < level; i++) {
-		buffer_fmt_add(buf, NULL, PRINT_JSON_INDENT);
+		_print_fmt(buf, PRINT_JSON_INDENT);
 	}
 }
 
@@ -41,7 +51,7 @@ void print_start_document(output_format_t format, struct buffer *buf, int level)
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, PRINT_JSON_START_ELEM);
+		_print_fmt(buf, PRINT_JSON_START_ELEM);
 	}
 }
 
@@ -49,7 +59,7 @@ void print_end_document(output_format_t format, struct buffer *buf, int level)
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "%s\n", PRINT_JSON_END_LAST);
+		_print_fmt(buf, "%s\n", PRINT_JSON_END_LAST);
 	}
 }
 
@@ -57,20 +67,20 @@ void print_start_array(char *array_name, output_format_t format, struct buffer *
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "\"%s\": %s", array_name, PRINT_JSON_START_ARRAY);
+		_print_fmt(buf, "\"%s\": %s", array_name, PRINT_JSON_START_ARRAY);
 	}
 }
 
 void print_end_array(bool needs_comma, output_format_t format, struct buffer *buf, int level)
 {
 	if (format == JSON) {
-		buffer_fmt_add(buf, NULL, "\n");
+		_print_fmt(buf, "\n");
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, PRINT_JSON_END_ARRAY);
+		_print_fmt(buf, PRINT_JSON_END_ARRAY);
 		if (needs_comma)
-			buffer_fmt_add(buf, NULL, "%s", ",\n");
+			_print_fmt(buf, "%s", ",\n");
 		else
-			buffer_fmt_add(buf, NULL, "%s", "\n");
+			_print_fmt(buf, "%s", "\n");
 	}
 }
 
@@ -78,11 +88,11 @@ void print_start_elem(bool needs_comma, output_format_t format, struct buffer *b
 {
 	if (format == JSON) {
 		if (needs_comma)
-			buffer_fmt_add(buf, NULL, ",\n");
+			_print_fmt(buf, ",\n");
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "%s", PRINT_JSON_START_ELEM);
+		_print_fmt(buf, "%s", PRINT_JSON_START_ELEM);
 	} else {
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+		_print_fmt(buf, "%s", "\n");
 	}
 }
 
@@ -90,9 +100,9 @@ void print_end_elem(output_format_t format, struct buffer *buf, int level)
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "%s", PRINT_JSON_END_LAST);
+		_print_fmt(buf, "%s", PRINT_JSON_END_LAST);
 	} else {
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+		_print_fmt(buf, "%s", "\n");
 	}
 }
 
@@ -100,16 +110,16 @@ void print_str_field(char *field_name, char *value, output_format_t format, stru
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "\"%s\": ", field_name);
-		buffer_fmt_add(buf, NULL, "\"%s\"", value);
+		_print_fmt(buf, "\"%s\": ", field_name);
+		_print_fmt(buf, "\"%s\"", value);
 		if (trailing_comma)
-			buffer_fmt_add(buf, NULL, ",");
-		buffer_fmt_add(buf, NULL, "\n");
+			_print_fmt(buf, ",");
+		_print_fmt(buf, "\n");
 	} else {
-		buffer_fmt_add(buf, NULL, "%s", field_name);
-		buffer_fmt_add(buf, NULL, "%s", ": ");
-		buffer_fmt_add(buf, NULL, "%s", value);
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+		_print_fmt(buf, "%s", field_name);
+		_print_fmt(buf, "%s", ": ");
+		_print_fmt(buf, "%s", value);
+		_print_fmt(buf, "%s", "\n");
 	}
 }
 
@@ -117,16 +127,16 @@ void print_uint_field(char *field_name, uint value, output_format_t format, stru
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "\"%s\": ", field_name);
-		buffer_fmt_add(buf, NULL, "%u", value);
+		_print_fmt(buf, "\"%s\": ", field_name);
+		_print_fmt(buf, "%u", value);
 		if (trailing_comma)
-			buffer_fmt_add(buf, NULL, ",");
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+			_print_fmt(buf, ",");
+		_print_fmt(buf, "%s", "\n");
 	} else {
-		buffer_fmt_add(buf, NULL, "%s", field_name);
-		buffer_fmt_add(buf, NULL, "%s", ": ");
-		buffer_fmt_add(buf, NULL, "%u", value);
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+		_print_fmt(buf, "%s", field_name);
+		_print_fmt(buf, "%s", ": ");
+		_print_fmt(buf, "%u", value);
+		_print_fmt(buf, "%s", "\n");
 	}
 }
 
@@ -139,16 +149,16 @@ void print_uint64_field(char *          field_name,
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "\"%s\": ", field_name);
-		buffer_fmt_add(buf, NULL, "%" PRIu64, value);
+		_print_fmt(buf, "\"%s\": ", field_name);
+		_print_fmt(buf, "%" PRIu64, value);
 		if (trailing_comma)
-			buffer_fmt_add(buf, NULL, ",");
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+			_print_fmt(buf, ",");
+		_print_fmt(buf, "%s", "\n");
 	} else {
-		buffer_fmt_add(buf, NULL, "%s", field_name);
-		buffer_fmt_add(buf, NULL, "%s", ": ");
-		buffer_fmt_add(buf, NULL, "%" PRIu64, value);
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+		_print_fmt(buf, "%s", field_name);
+		_print_fmt(buf, "%s", ": ");
+		_print_fmt(buf, "%" PRIu64, value);
+		_print_fmt(buf, "%s", "\n");
 	}
 }
 
@@ -156,16 +166,16 @@ void print_int64_field(char *field_name, uint64_t value, output_format_t format,
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "\"%s\": ", field_name);
-		buffer_fmt_add(buf, NULL, "%" PRIu64, value);
+		_print_fmt(buf, "\"%s\": ", field_name);
+		_print_fmt(buf, "%" PRIu64, value);
 		if (trailing_comma)
-			buffer_fmt_add(buf, NULL, ",");
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+			_print_fmt(buf, ",");
+		_print_fmt(buf, "%s", "\n");
 	} else {
-		buffer_fmt_add(buf, NULL, "%s", field_name);
-		buffer_fmt_add(buf, NULL, "%s", ": ");
-		buffer_fmt_add(buf, NULL, "%" PRIu64, value);
-		buffer_fmt_add(buf, NULL, "%s", "\n");
+		_print_fmt(buf, "%s", field_name);
+		_print_fmt(buf, "%s", ": ");
+		_print_fmt(buf, "%" PRIu64, value);
+		_print_fmt(buf, "%s", "\n");
 	}
 }
 
@@ -173,13 +183,13 @@ void print_bool_array_elem(char *field_name, bool value, output_format_t format,
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "{\"%s\": %s}", field_name, value ? "true" : "false");
+		_print_fmt(buf, "{\"%s\": %s}", field_name, value ? "true" : "false");
 		if (trailing_comma)
-			buffer_fmt_add(buf, NULL, "%s", ",\n");
+			_print_fmt(buf, "%s", ",\n");
 	} else {
 		if (value) {
-			buffer_fmt_add(buf, NULL, "%s", field_name);
-			buffer_fmt_add(buf, NULL, "%s", "\n");
+			_print_fmt(buf, "%s", field_name);
+			_print_fmt(buf, "%s", "\n");
 		}
 	}
 }
@@ -188,11 +198,11 @@ void print_uint_array_elem(uint value, output_format_t format, struct buffer *bu
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "%u", value);
+		_print_fmt(buf, "%u", value);
 		if (trailing_comma)
-			buffer_fmt_add(buf, NULL, "%s", ",\n");
+			_print_fmt(buf, "%s", ",\n");
 	} else {
-		buffer_fmt_add(buf, NULL, "%u", value);
+		_print_fmt(buf, "%u", value);
 	}
 }
 
@@ -200,11 +210,16 @@ void print_str_array_elem(char *value, output_format_t format, struct buffer *bu
 {
 	if (format == JSON) {
 		print_indent(level, buf);
-		buffer_fmt_add(buf, NULL, "\"%s\"", value);
+		_print_fmt(buf, "\"%s\"", value);
 		if (trailing_comma)
-			buffer_fmt_add(buf, NULL, "%s", ",\n");
+			_print_fmt(buf, "%s", ",\n");
 	} else {
-		buffer_fmt_add(buf, NULL, "%s", value);
-		buffer_fmt_add(buf, NULL, "\n");
+		_print_fmt(buf, "%s", value);
+		_print_fmt(buf, "\n");
 	}
+}
+
+void print_null_byte(struct buffer *buf)
+{
+	buffer_fmt_add(buf, NULL, "");
 }

--- a/src/include/base/formatter.h
+++ b/src/include/base/formatter.h
@@ -67,6 +67,7 @@ void print_bool_array_elem(char *          field_name,
                            int             level);
 void print_uint_array_elem(uint value, output_format_t format, struct buffer *buf, bool trailing_comma, int level);
 void print_str_array_elem(char *value, output_format_t format, struct buffer *buf, bool trailing_comma, int level);
+void print_null_byte(struct buffer *buf);
 
 #ifdef __cplusplus
 }

--- a/src/include/iface/usid.h
+++ b/src/include/iface/usid.h
@@ -125,7 +125,8 @@ int        usid_req(const char *       prefix,
                     uint64_t           status,
                     usid_req_data_fn_t data_fn,
                     void *             data_fn_arg,
-                    struct buffer **   resp_buf);
+                    struct buffer **   resp_buf,
+                    int *              resp_fd);
 
 #ifdef __cplusplus
 }

--- a/src/include/iface/usid.h
+++ b/src/include/iface/usid.h
@@ -70,9 +70,9 @@ bool usid_cmd_root_only[] = {
 	[USID_CMD_REPLY]      = false,
 	[USID_CMD_SCAN]       = true,
 	[USID_CMD_VERSION]    = false,
-	[USID_CMD_DUMP]       = false,
-	[USID_CMD_STATS]      = false,
-	[USID_CMD_TREE]       = false,
+	[USID_CMD_DUMP]       = true,
+	[USID_CMD_STATS]      = true,
+	[USID_CMD_TREE]       = true,
 };
 
 #define COMMAND_STATUS_MASK_OVERALL UINT64_C(0x0000000000000001)

--- a/src/include/resource/ucmd-module.h
+++ b/src/include/resource/ucmd-module.h
@@ -22,6 +22,7 @@
 
 #include "base/common.h"
 
+#include "base/formatter.h"
 #include "resource/module.h"
 
 #include <inttypes.h>
@@ -208,6 +209,7 @@ int sid_ucmd_group_destroy(struct module *         mod,
                            const char *            group_id,
                            int                     force);
 
+int sid_ucmd_print_exported_kv_store(const char *prefix, char *ptr, size_t size, output_format_t format, struct buffer *outbuf);
 #ifdef __cplusplus
 }
 #endif

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3226,7 +3226,7 @@ static int _export_kv_store(sid_resource_t *cmd_res)
 	kv_store_value_flags_t  flags;
 	struct iovec *          iov;
 	int                     export_fd     = -1;
-	size_t                  bytes_written = 0;
+	size_t                  bytes_written = sizeof(bytes_written);
 	struct worker_data_spec data_spec;
 	unsigned                i;
 	ssize_t                 r_wr;
@@ -3415,7 +3415,7 @@ static int _export_kv_store(sid_resource_t *cmd_res)
 	data_spec.ext.used           = true;
 	data_spec.ext.socket.fd_pass = export_fd;
 
-	if (bytes_written)
+	if (bytes_written > sizeof(bytes_written))
 		worker_control_channel_send(cmd_res, MAIN_WORKER_CHANNEL_ID, &data_spec);
 
 	r = 0;
@@ -3839,8 +3839,8 @@ static int _sync_main_kv_store(sid_resource_t *worker_proxy_res, sid_resource_t 
 		goto out;
 	}
 
-	p += sizeof(msg_size);
 	end = p + msg_size;
+	p += sizeof(msg_size);
 
 	while (p < end) {
 		flags = *((kv_store_value_flags_t *) p);

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3304,6 +3304,7 @@ static int _export_kv_store(sid_resource_t *cmd_res)
 				          INTERNAL_ERROR "%s: Unsupported vector value for key %s in udev namespace.",
 				          __func__,
 				          key);
+				r = -ENOTSUP;
 				goto out;
 			}
 			key = _get_key_part(key, KEY_PART_CORE, NULL);

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3471,8 +3471,11 @@ out:
 	if (r < 0)
 		response_header.status |= COMMAND_STATUS_FAILURE;
 
-	if (buffer_write_all(ucmd_ctx->res_buf, conn->fd) < 0)
+	if (buffer_write_all(ucmd_ctx->res_buf, conn->fd) < 0) {
 		(void) _connection_cleanup(conn_res);
+		log_error(ID(cmd_res), "Failed to write out command response");
+		r = -1;
+	}
 
 	return r;
 }

--- a/src/tools/sidctl/Makefile.am
+++ b/src/tools/sidctl/Makefile.am
@@ -23,4 +23,5 @@ sidctl_SOURCES = sidctl.c
 
 sidctl_LDADD = $(top_builddir)/src/base/libsidbase.la \
 	       $(top_builddir)/src/iface/libsidiface_usid.la \
-	       $(top_builddir)/src/log/libsidlog.la
+	       $(top_builddir)/src/log/libsidlog.la \
+	       $(top_builddir)/src/resource/libsidresource.la

--- a/src/tools/sidctl/sidctl.c
+++ b/src/tools/sidctl/sidctl.c
@@ -55,7 +55,7 @@ static int _usid_cmd_tree(struct args *args, output_format_t format, struct buff
 	struct usid_msg_header *msg;
 	int                     r;
 
-	if ((r = usid_req(LOG_PREFIX, USID_CMD_TREE, 0, NULL, NULL, &readbuf)) == 0) {
+	if ((r = usid_req(LOG_PREFIX, USID_CMD_TREE, 0, NULL, NULL, &readbuf, NULL)) == 0) {
 		buffer_get_data(readbuf, (const void **) &msg, &size);
 		if (size < USID_MSG_HEADER_SIZE || msg->status & COMMAND_STATUS_FAILURE) {
 			buffer_destroy(readbuf);
@@ -81,7 +81,7 @@ static int _usid_cmd_dump(struct args *args, output_format_t format, struct buff
 	uint32_t                len;
 	bool                    needs_comma = false;
 
-	if ((r = usid_req(LOG_PREFIX, USID_CMD_DUMP, 0, NULL, NULL, &readbuf)) == 0) {
+	if ((r = usid_req(LOG_PREFIX, USID_CMD_DUMP, 0, NULL, NULL, &readbuf, NULL)) == 0) {
 		buffer_get_data(readbuf, (const void **) &msg, &size);
 		if (size < USID_MSG_HEADER_SIZE || msg->status & COMMAND_STATUS_FAILURE) {
 			buffer_destroy(readbuf);
@@ -157,7 +157,7 @@ static int _usid_cmd_stats(struct args *args, output_format_t format, struct buf
 	struct usid_stats *     stats = NULL;
 	int                     r;
 
-	if ((r = usid_req(LOG_PREFIX, USID_CMD_STATS, 0, NULL, NULL, &buf)) == 0) {
+	if ((r = usid_req(LOG_PREFIX, USID_CMD_STATS, 0, NULL, NULL, &buf, NULL)) == 0) {
 		buffer_get_data(buf, (const void **) &hdr, &size);
 
 		if (size >= (USID_MSG_HEADER_SIZE + USID_STATS_SIZE) &&
@@ -187,7 +187,7 @@ static int _usid_cmd_version(struct args *args, output_format_t format, struct b
 	size_t                  size;
 	struct usid_version *   vsn = NULL;
 	int                     r;
-	r = usid_req(LOG_PREFIX, USID_CMD_VERSION, 0, NULL, NULL, &readbuf);
+	r = usid_req(LOG_PREFIX, USID_CMD_VERSION, 0, NULL, NULL, &readbuf, NULL);
 
 	print_start_document(format, outbuf, 0);
 

--- a/src/tools/usid/usid.c
+++ b/src/tools/usid/usid.c
@@ -70,7 +70,7 @@ static int _usid_cmd_active(struct args *args)
 
 	seqnum = util_env_get_ull(KEY_ENV_SEQNUM, 0, UINT64_MAX, &val) < 0 ? 0 : val;
 
-	if ((r = usid_req(LOG_PREFIX, USID_CMD_VERSION, seqnum, NULL, NULL, &buf)) == 0) {
+	if ((r = usid_req(LOG_PREFIX, USID_CMD_VERSION, seqnum, NULL, NULL, &buf, NULL)) == 0) {
 		buffer_get_data(buf, (const void **) &hdr, &size);
 
 		if ((size >= (USID_MSG_HEADER_SIZE + USID_VERSION_SIZE)) && (hdr->prot == USID_PROTOCOL))
@@ -192,7 +192,7 @@ static int _usid_cmd_checkpoint(struct args *args)
 
 	seqnum = val;
 
-	if ((r = usid_req(LOG_PREFIX, USID_CMD_CHECKPOINT, seqnum, _add_checkpoint_env_to_buf, args, &buf)) == 0) {
+	if ((r = usid_req(LOG_PREFIX, USID_CMD_CHECKPOINT, seqnum, _add_checkpoint_env_to_buf, args, &buf, NULL)) == 0) {
 		r = _print_env_from_buffer(buf);
 		buffer_destroy(buf);
 	}
@@ -230,7 +230,7 @@ static int _usid_cmd_scan(struct args *args)
 
 	seqnum = val;
 
-	if ((r = usid_req(LOG_PREFIX, USID_CMD_SCAN, seqnum, _add_scan_env_to_buf, NULL, &buf)) == 0) {
+	if ((r = usid_req(LOG_PREFIX, USID_CMD_SCAN, seqnum, _add_scan_env_to_buf, NULL, &buf, NULL)) == 0) {
 		r = _print_env_from_buffer(buf);
 		buffer_destroy(buf);
 	}
@@ -258,7 +258,7 @@ static int _usid_cmd_version(struct args *args)
 	        SID_VERSION_MINOR,
 	        SID_VERSION_RELEASE);
 
-	if ((r = usid_req(LOG_PREFIX, USID_CMD_VERSION, seqnum, NULL, NULL, &buf)) == 0) {
+	if ((r = usid_req(LOG_PREFIX, USID_CMD_VERSION, seqnum, NULL, NULL, &buf, NULL)) == 0) {
 		buffer_get_data(buf, (const void **) &hdr, &size);
 
 		if (size >= (USID_MSG_HEADER_SIZE + USID_VERSION_SIZE)) {


### PR DESCRIPTION
This patchset makes _export_kv_store() use a memfd backed buffer, and uses the same code to build the kv dump for sidctl.