### PR TITLE
Binary encode

### DIFF
--- a/BSD_LICENSE
+++ b/BSD_LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2002-2012, Jouni Malinen <j@w1.fi> and contributors
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name(s) of the above-listed copyright holder(s) nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/rpm/sid.spec
+++ b/rpm/sid.spec
@@ -79,7 +79,7 @@ rm -f %{buildroot}/%{_libdir}/sid/modules/ucmd/type/*.{a,la}
 %multilib_fix_c_header --file %{_includedir}/sid/config.h
 
 %files
-%license COPYING
+%license COPYING BSD_LICENSE
 %{_sbindir}/sid
 %config(noreplace) %{_sysconfdir}/sysconfig/sid.sysconfig
 %{_udevrulesdir}/00-sid.rules

--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -29,7 +29,8 @@ libsidbase_la_SOURCES = mem.c \
 			comms.c \
 			util.c \
 			hash.c \
-			formatter.c
+			formatter.c \
+			base64.c
 
 basedir = $(pkgincludedir)/base
 

--- a/src/base/base64.c
+++ b/src/base/base64.c
@@ -1,0 +1,152 @@
+/*
+ * Base64 encoding/decoding (RFC1341)
+ * Copyright (c) 2005-2011, Jouni Malinen <j@w1.fi>
+ * Copyright (c) 2021 Red Hat, Inc. All rights reserved.
+ *
+ * This software may be distributed under the terms of the BSD license.
+ * See BSD_LICENSE for more details.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "base/base64.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static const unsigned char base64_table[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * base64_encode - Base64 encode
+ * @src: Data to be encoded
+ * @len: Length of the data to be encoded
+ * @out_len: Pointer to output length variable, or %NULL if not used
+ * Returns: Allocated buffer of out_len bytes of encoded data,
+ * or %NULL on failure
+ *
+ * Caller is responsible for freeing the returned buffer. Returned buffer is
+ * nul terminated to make it easier to use as a C string. The nul terminator is
+ * not included in out_len.
+ */
+unsigned char *base64_encode(const unsigned char *src, size_t len, size_t *out_len)
+{
+	unsigned char *      out, *pos;
+	const unsigned char *end, *in;
+	size_t               olen;
+	int                  line_len;
+
+	olen = len * 4 / 3 + 4; /* 3-byte blocks to 4-byte */
+	olen += olen / 72;      /* line feeds */
+	olen++;                 /* nul termination */
+	if (olen < len)
+		return NULL; /* integer overflow */
+	out = malloc(olen);
+	if (out == NULL)
+		return NULL;
+
+	end      = src + len;
+	in       = src;
+	pos      = out;
+	line_len = 0;
+	while (end - in >= 3) {
+		*pos++ = base64_table[in[0] >> 2];
+		*pos++ = base64_table[((in[0] & 0x03) << 4) | (in[1] >> 4)];
+		*pos++ = base64_table[((in[1] & 0x0f) << 2) | (in[2] >> 6)];
+		*pos++ = base64_table[in[2] & 0x3f];
+		in += 3;
+		line_len += 4;
+		if (line_len >= 72) {
+			*pos++   = '\n';
+			line_len = 0;
+		}
+	}
+
+	if (end - in) {
+		*pos++ = base64_table[in[0] >> 2];
+		if (end - in == 1) {
+			*pos++ = base64_table[(in[0] & 0x03) << 4];
+			*pos++ = '=';
+		} else {
+			*pos++ = base64_table[((in[0] & 0x03) << 4) | (in[1] >> 4)];
+			*pos++ = base64_table[(in[1] & 0x0f) << 2];
+		}
+		*pos++ = '=';
+		line_len += 4;
+	}
+
+	if (line_len)
+		*pos++ = '\n';
+
+	*pos = '\0';
+	if (out_len)
+		*out_len = pos - out;
+	return out;
+}
+
+/**
+ * base64_decode - Base64 decode
+ * @src: Data to be decoded
+ * @len: Length of the data to be decoded
+ * @out_len: Pointer to output length variable
+ * Returns: Allocated buffer of out_len bytes of decoded data,
+ * or %NULL on failure
+ *
+ * Caller is responsible for freeing the returned buffer.
+ */
+unsigned char *base64_decode(const unsigned char *src, size_t len, size_t *out_len)
+{
+	unsigned char dtable[256], *out, *pos, block[4], tmp;
+	size_t        i, count, olen;
+	int           pad = 0;
+
+	memset(dtable, 0x80, 256);
+	for (i = 0; i < sizeof(base64_table) - 1; i++)
+		dtable[base64_table[i]] = (unsigned char) i;
+	dtable['='] = 0;
+
+	count = 0;
+	for (i = 0; i < len; i++) {
+		if (dtable[src[i]] != 0x80)
+			count++;
+	}
+
+	if (count == 0 || count % 4)
+		return NULL;
+
+	olen = count / 4 * 3;
+	pos = out = malloc(olen);
+	if (out == NULL)
+		return NULL;
+
+	count = 0;
+	for (i = 0; i < len; i++) {
+		tmp = dtable[src[i]];
+		if (tmp == 0x80)
+			continue;
+
+		if (src[i] == '=')
+			pad++;
+		block[count] = tmp;
+		count++;
+		if (count == 4) {
+			*pos++ = (block[0] << 2) | (block[1] >> 4);
+			*pos++ = (block[1] << 4) | (block[2] >> 2);
+			*pos++ = (block[2] << 6) | block[3];
+			count  = 0;
+			if (pad) {
+				if (pad == 1)
+					pos--;
+				else if (pad == 2)
+					pos -= 2;
+				else {
+					/* Invalid padding */
+					free(out);
+					return NULL;
+				}
+				break;
+			}
+		}
+	}
+
+	*out_len = pos - out;
+	return out;
+}

--- a/src/base/buffer-type-linear.c
+++ b/src/base/buffer-type-linear.c
@@ -154,7 +154,10 @@ static const void *_buffer_linear_add(struct buffer *buf, void *data, size_t len
 		goto out;
 
 	start = buf->mem + used;
-	memcpy(start, data, len);
+	if (data)
+		memcpy(start, data, len);
+	else
+		memset(start, 0, len);
 	buf->stat.usage.used = used + len;
 out:
 	if (ret_code)

--- a/src/base/buffer-type-linear.c
+++ b/src/base/buffer-type-linear.c
@@ -209,6 +209,9 @@ static int _buffer_linear_rewind(struct buffer *buf, size_t pos)
 {
 	size_t min_pos = (buf->stat.spec.mode == BUFFER_MODE_SIZE_PREFIX) ? BUFFER_SIZE_PREFIX_LEN : 0;
 
+	if (!buf->stat.usage.used && pos == min_pos)
+		return 0;
+
 	if (pos > buf->stat.usage.used || pos < min_pos)
 		return -EINVAL;
 
@@ -262,7 +265,7 @@ static int _buffer_linear_get_data(struct buffer *buf, const void **data, size_t
 			if (data)
 				*data = buf->mem + BUFFER_SIZE_PREFIX_LEN;
 			if (data_size)
-				*data_size = buf->stat.usage.used - BUFFER_SIZE_PREFIX_LEN;
+				*data_size = (buf->stat.usage.used) ? buf->stat.usage.used - BUFFER_SIZE_PREFIX_LEN : 0;
 			break;
 		default:
 			return -ENOTSUP;

--- a/src/base/buffer-type-vector.c
+++ b/src/base/buffer-type-vector.c
@@ -184,9 +184,9 @@ const void *_buffer_vector_add(struct buffer *buf, void *data, size_t len, int *
 	struct iovec *iov;
 	int           r;
 
-	if (buf == NULL || buf->mem == NULL) {
+	if (buf == NULL || buf->mem == NULL || data == NULL) {
 		if (ret_code)
-			*ret_code = EINVAL;
+			*ret_code = -EINVAL;
 		return NULL;
 	}
 

--- a/src/base/buffer-type-vector.c
+++ b/src/base/buffer-type-vector.c
@@ -221,6 +221,9 @@ int _buffer_vector_rewind(struct buffer *buf, size_t pos)
 {
 	size_t min_pos = (buf->stat.spec.mode == BUFFER_MODE_SIZE_PREFIX) ? 1 : 0;
 
+	if (!buf->stat.usage.used && pos == min_pos)
+		return 0;
+
 	if (pos > buf->stat.usage.used || pos < min_pos)
 		return -EINVAL;
 
@@ -269,7 +272,7 @@ int _buffer_vector_get_data(struct buffer *buf, const void **data, size_t *data_
 			if (data)
 				*data = buf->mem + VECTOR_ITEM_SIZE;
 			if (data_size)
-				*data_size = buf->stat.usage.used - 1;
+				*data_size = (buf->stat.usage.used) ? buf->stat.usage.used - 1 : 0;
 			break;
 		default:
 			return -ENOTSUP;

--- a/src/base/buffer.c
+++ b/src/base/buffer.c
@@ -124,6 +124,8 @@ const void *buffer_vfmt_add(struct buffer *buf, int *ret_code, const char *fmt, 
 int buffer_rewind(struct buffer *buf, size_t pos, buffer_pos_t whence)
 {
 	if (whence == BUFFER_POS_REL) {
+		if (pos == 0)
+			return 0; /* otherwise this fails on an empty size-prefixed buffer */
 		if (pos > buf->stat.usage.used)
 			return -EINVAL;
 

--- a/src/base/buffer.c
+++ b/src/base/buffer.c
@@ -101,12 +101,6 @@ int buffer_reset(struct buffer *buf)
 
 const void *buffer_add(struct buffer *buf, void *data, size_t len, int *ret_code)
 {
-	if (!data) {
-		if (*ret_code)
-			*ret_code = -EINVAL;
-		return NULL;
-	}
-
 	return _buffer_type_registry[buf->stat.spec.type]->add(buf, data, len, ret_code);
 }
 

--- a/src/include/base/base64.h
+++ b/src/include/base/base64.h
@@ -1,0 +1,18 @@
+/*
+ * Base64 encoding/decoding (RFC1341)
+ * Copyright (c) 2005, Jouni Malinen <j@w1.fi>
+ *
+ * This software may be distributed under the terms of the BSD license.
+ * See BSD_LICENSE for more details.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef BASE64_H
+#define BASE64_H
+
+#include <stddef.h>
+
+unsigned char *base64_encode(const unsigned char *src, size_t len, size_t *out_len);
+unsigned char *base64_decode(const unsigned char *src, size_t len, size_t *out_len);
+
+#endif /* BASE64_H */

--- a/src/include/base/base64.h
+++ b/src/include/base/base64.h
@@ -12,7 +12,8 @@
 
 #include <stddef.h>
 
-unsigned char *base64_encode(const unsigned char *src, size_t len, size_t *out_len);
+size_t         base64_len_encode(size_t in_len);
+int            base64_encode(const unsigned char *src, size_t len, unsigned char *dest, size_t out_len);
 unsigned char *base64_decode(const unsigned char *src, size_t len, size_t *out_len);
 
 #endif /* BASE64_H */

--- a/src/include/base/formatter.h
+++ b/src/include/base/formatter.h
@@ -45,6 +45,13 @@ void print_end_array(bool needs_comma, output_format_t format, struct buffer *bu
 void print_start_elem(bool needs_comma, output_format_t format, struct buffer *buf, int level);
 void print_end_elem(output_format_t format, struct buffer *buf, int level);
 void print_str_field(char *field_name, char *value, output_format_t format, struct buffer *buf, bool trailing_comma, int level);
+void print_binary_field(char *          field_name,
+                        char *          value,
+                        size_t          len,
+                        output_format_t format,
+                        struct buffer * buf,
+                        bool            trailing_comma,
+                        int             level);
 void print_uint_field(char *field_name, uint value, output_format_t format, struct buffer *buf, bool trailing_comma, int level);
 void print_uint64_field(char *          field_name,
                         uint64_t        value,
@@ -66,6 +73,7 @@ void print_bool_array_elem(char *          field_name,
                            int             level);
 void print_uint_array_elem(uint value, output_format_t format, struct buffer *buf, bool trailing_comma, int level);
 void print_str_array_elem(char *value, output_format_t format, struct buffer *buf, bool trailing_comma, int level);
+void print_binary_array_elem(char *value, size_t len, output_format_t format, struct buffer *buf, bool trailing_comma, int level);
 void print_null_byte(struct buffer *buf);
 
 #ifdef __cplusplus

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3957,6 +3957,11 @@ static int _sync_main_kv_store(sid_resource_t *worker_proxy_res, sid_resource_t 
 		goto out;
 	}
 
+	if (msg_size <= BUFFER_SIZE_PREFIX_LEN) { /* nothing to sync */
+		r = 0;
+		goto out;
+	}
+
 	if ((p = shm = mmap(NULL, msg_size, PROT_READ, MAP_SHARED, fd, 0)) == MAP_FAILED) {
 		log_error_errno(ID(worker_proxy_res), errno, "Failed to map memory with key-value store");
 		goto out;

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3934,7 +3934,7 @@ static int _sync_main_kv_store(sid_resource_t *worker_proxy_res, sid_resource_t 
 	kv_store_value_flags_t  flags;
 	BUFFER_SIZE_PREFIX_TYPE msg_size;
 	size_t                  full_key_size, data_size, data_offset, i;
-	char *                  full_key, *shm = NULL, *p, *end;
+	char *                  full_key, *shm = MAP_FAILED, *p, *end;
 	struct kv_value *       value = NULL;
 	struct iovec *          iov   = NULL;
 	const char *            iov_str;
@@ -4092,7 +4092,7 @@ static int _sync_main_kv_store(sid_resource_t *worker_proxy_res, sid_resource_t 
 out:
 	free(iov);
 
-	if (shm && munmap(shm, msg_size) < 0) {
+	if (shm != MAP_FAILED && munmap(shm, msg_size) < 0) {
 		log_error_errno(ID(worker_proxy_res), errno, "Failed to unmap memory with key-value store");
 		r = -1;
 	}

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3655,6 +3655,10 @@ static int _on_connection_event(sid_resource_event_source_t *es, int fd, uint32_
 		if (buffer_is_complete(conn->buf, NULL)) {
 			(void) buffer_get_data(conn->buf, (const void **) &msg.header, &msg.size);
 
+			if (msg.size < sizeof(struct usid_msg_header)) {
+				(void) _connection_cleanup(conn_res);
+				return -1;
+			}
 			/* Sanitize command number - map all out of range command numbers to CMD_UNKNOWN. */
 			if (msg.header->cmd < _USID_CMD_START || msg.header->cmd > _USID_CMD_END)
 				msg.header->cmd = USID_CMD_UNKNOWN;

--- a/src/tools/sidctl/sidctl.c
+++ b/src/tools/sidctl/sidctl.c
@@ -79,7 +79,7 @@ static int _usid_cmd_dump(struct args *args, output_format_t format, struct buff
 	struct usid_msg_header *msg;
 	int                     r;
 	int                     fd  = -1;
-	char *                  shm = NULL;
+	char *                  shm = MAP_FAILED;
 
 	if ((r = usid_req(LOG_PREFIX, USID_CMD_DUMP, 0, NULL, NULL, &readbuf, &fd)) < 0)
 		return r;
@@ -111,7 +111,7 @@ static int _usid_cmd_dump(struct args *args, output_format_t format, struct buff
 	                                     format,
 	                                     outbuf);
 out:
-	if (shm && munmap(shm, msg_size) < 0) {
+	if (shm != MAP_FAILED && munmap(shm, msg_size) < 0) {
 		log_error_errno(LOG_PREFIX, errno, "Failed to unmap memory with key-value store");
 		r = -1;
 	}

--- a/src/tools/sidctl/sidctl.c
+++ b/src/tools/sidctl/sidctl.c
@@ -95,6 +95,10 @@ static int _usid_cmd_dump(struct args *args, output_format_t format, struct buff
 		r = -errno;
 		goto out;
 	}
+	if (msg_size <= BUFFER_SIZE_PREFIX_LEN) {
+		r = sid_ucmd_print_exported_kv_store(LOG_PREFIX, NULL, 0, format, outbuf);
+		goto out;
+	}
 	if ((shm = mmap(NULL, msg_size, PROT_READ, MAP_SHARED, fd, 0)) == MAP_FAILED) {
 		log_error_errno(LOG_PREFIX, errno, "Failed to map memory with key-value store");
 		r = -errno;


### PR DESCRIPTION
This patchset adds support for dumping udev variables in sidctl, and printing binary dump data in base64 encoding. A number of the changes for encoding the base64 data are there to avoid mallocing memory for the encoded data, which would just be freed after writing it to the memfd buffer. If you don't care about the extra malloc for binary data, this patchset can get simplified.