### PR TITLE
minor kv cleanups

### DIFF
--- a/src/include/resource/kv-store.h
+++ b/src/include/resource/kv-store.h
@@ -62,6 +62,7 @@ struct sid_kv_store_resource_params {
 };
 
 struct kv_store_update_spec {
+	const char *              key;
 	void *                    old_data;
 	size_t                    old_data_size;
 	kv_store_value_flags_t    old_flags;
@@ -76,7 +77,7 @@ struct kv_store_update_spec {
  *   0 to keep old_data
  *   1 to update old_data with new_data
  */
-typedef int (*kv_store_update_fn_t)(const char *key, struct kv_store_update_spec *update_spec, void *arg);
+typedef int (*kv_store_update_fn_t)(struct kv_store_update_spec *update_spec, void *arg);
 
 // clang-format off
 /*

--- a/src/include/resource/kv-store.h
+++ b/src/include/resource/kv-store.h
@@ -70,6 +70,7 @@ struct kv_store_update_spec {
 	size_t                    new_data_size;
 	kv_store_value_flags_t    new_flags;
 	kv_store_value_op_flags_t op_flags;
+	void *                    arg; /* kv_update_fn_arg or kv_unset_fn_arg from kv_store_set/unset_value call */
 };
 
 /*
@@ -77,7 +78,7 @@ struct kv_store_update_spec {
  *   0 to keep old_data
  *   1 to update old_data with new_data
  */
-typedef int (*kv_store_update_fn_t)(struct kv_store_update_spec *update_spec, void *arg);
+typedef int (*kv_store_update_fn_t)(struct kv_store_update_spec *update_spec);
 
 // clang-format off
 /*

--- a/src/resource/kv-store.c
+++ b/src/resource/kv-store.c
@@ -303,7 +303,9 @@ static int _hash_update_fn(const char *               key,
 		update_spec.new_data_size = orig_new_data_size = orig_new_value->size;
 		update_spec.new_flags = orig_new_flags = orig_new_value->ext_flags;
 
-		r = relay->kv_update_fn(&update_spec, relay->kv_update_fn_arg);
+		update_spec.arg = relay->kv_update_fn_arg;
+
+		r = relay->kv_update_fn(&update_spec);
 
 		/* Check if there has been any change... */
 		if ((r > 0) && ((update_spec.new_data != orig_new_data) || (update_spec.new_data_size != orig_new_data_size) ||
@@ -437,7 +439,9 @@ int kv_store_unset_value(sid_resource_t *kv_store_res, const char *key, kv_store
 	update_spec.old_data_size = found->size;
 	update_spec.old_flags     = found->ext_flags;
 
-	if (kv_unset_fn && !kv_unset_fn(&update_spec, kv_unset_fn_arg))
+	update_spec.arg = kv_unset_fn_arg;
+
+	if (kv_unset_fn && !kv_unset_fn(&update_spec))
 		return -EREMOTEIO;
 
 	_destroy_kv_store_value(found);


### PR DESCRIPTION
Make `key` and `arg` parameters a part of existing `struct kv_store_update_spec` so all fields related to the KV record update are in one place, not passing them separately to each update function/subfunction.