### PR TITLE
kv-store: optionally return the key with calls to kv_store_iter_next()

### DIFF
--- a/src/include/resource/kv-store.h
+++ b/src/include/resource/kv-store.h
@@ -161,7 +161,7 @@ int              kv_store_iter_current_size(kv_store_iter_t *iter,
                                             size_t *         ext_data_size);
 const char *     kv_store_iter_current_key(kv_store_iter_t *iter);
 void *           kv_store_iter_current(kv_store_iter_t *iter, size_t *size, kv_store_value_flags_t *flags);
-void *           kv_store_iter_next(kv_store_iter_t *iter, size_t *size, kv_store_value_flags_t *flags);
+void *           kv_store_iter_next(kv_store_iter_t *iter, size_t *size, const char **return_key, kv_store_value_flags_t *flags);
 void             kv_store_iter_reset(kv_store_iter_t *iter);
 void             kv_store_iter_destroy(kv_store_iter_t *iter);
 

--- a/src/resource/kv-store.c
+++ b/src/resource/kv-store.c
@@ -529,9 +529,12 @@ const char *kv_store_iter_current_key(kv_store_iter_t *iter)
 	return iter->current ? hash_get_key(iter->store->ht, iter->current, NULL) : NULL;
 }
 
-void *kv_store_iter_next(kv_store_iter_t *iter, size_t *size, kv_store_value_flags_t *flags)
+void *kv_store_iter_next(kv_store_iter_t *iter, size_t *size, const char **return_key, kv_store_value_flags_t *flags)
 {
 	iter->current = iter->current ? hash_get_next(iter->store->ht, iter->current) : hash_get_first(iter->store->ht);
+
+	if (return_key != NULL)
+		*return_key = kv_store_iter_current_key(iter);
 
 	return kv_store_iter_current(iter, size, flags);
 }

--- a/tests/test_kv_store.c
+++ b/tests/test_kv_store.c
@@ -105,6 +105,7 @@ static void test_kvstore_iterate(void **state)
 {
 	struct iovec           test_iov[_KV_VALUE_IDX_COUNT];
 	size_t                 data_size, kv_size;
+	const char *           key;
 	struct iovec *         return_iov;
 	kv_store_iter_t *      iter;
 	sid_ucmd_kv_flags_t    ucmd_flags = DEFAULT_KV_FLAGS_CORE;
@@ -145,7 +146,8 @@ static void test_kvstore_iterate(void **state)
 
 	assert_ptr_not_equal(iter = kv_store_iter_create(kv_store_res), NULL);
 	/* validate the contents of the kv store */
-	while ((return_iov = kv_store_iter_next(iter, &data_size, &flags))) {
+	while ((return_iov = kv_store_iter_next(iter, &data_size, &key, &flags))) {
+		assert_int_equal(strcmp(TEST_KEY, key), 0);
 		assert_true(flags == KV_STORE_VALUE_VECTOR);
 		assert_int_equal(strcmp(return_iov[KV_VALUE_IDX_DATA].iov_base, "test"), 0);
 		assert_int_equal(return_iov[KV_VALUE_IDX_DATA].iov_len, sizeof("test"));
@@ -228,6 +230,7 @@ static void test_kvstore_merge_op(void **state)
 {
 	struct iovec           test_iov[MAX_TEST_ENTRIES];
 	size_t                 data_size;
+	const char *           key;
 	void *                 data;
 	kv_store_iter_t *      iter;
 	kv_store_value_flags_t flags        = KV_STORE_VALUE_VECTOR;
@@ -252,7 +255,8 @@ static void test_kvstore_merge_op(void **state)
 	 * returned as an iovec.*/
 	assert_int_equal(validate_merged_data(MAX_TEST_ENTRIES, data), 0);
 	assert_ptr_not_equal(iter = kv_store_iter_create(kv_store_res), NULL);
-	while ((data = kv_store_iter_next(iter, &data_size, &flags))) {
+	while ((data = kv_store_iter_next(iter, &data_size, &key, &flags))) {
+		assert_int_equal(strcmp(MERGE_KEY, key), 0);
 		assert_int_equal(validate_merged_data(MAX_TEST_ENTRIES, data), 0);
 	}
 


### PR DESCRIPTION
Most of the calls to kv_store_iter_next() subsequently call
kv_store_iter_current_key().  Update to return the key in the same call.

Signed-off-by: Todd Gill <tgill@redhat.com>