### PR TITLE
Worker cleanup

### DIFF
--- a/src/include/resource/worker-control.h
+++ b/src/include/resource/worker-control.h
@@ -133,6 +133,7 @@ struct worker_params {
 };
 
 int worker_control_get_new_worker(sid_resource_t *worker_control_res, struct worker_params *params, sid_resource_t **res_p);
+int worker_control_run_worker(sid_resource_t *worker_control_res);
 sid_resource_t *worker_control_get_idle_worker(sid_resource_t *worker_control_res);
 sid_resource_t *worker_control_find_worker(sid_resource_t *worker_control_res, const char *id);
 

--- a/src/include/resource/worker-control.h
+++ b/src/include/resource/worker-control.h
@@ -132,7 +132,7 @@ struct worker_params {
 	};
 };
 
-sid_resource_t *worker_control_get_new_worker(sid_resource_t *worker_control_res, struct worker_params *params);
+int worker_control_get_new_worker(sid_resource_t *worker_control_res, struct worker_params *params, sid_resource_t **res_p);
 sid_resource_t *worker_control_get_idle_worker(sid_resource_t *worker_control_res);
 sid_resource_t *worker_control_find_worker(sid_resource_t *worker_control_res, const char *id);
 

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -4170,7 +4170,7 @@ static sid_resource_t *_get_worker(sid_resource_t *ubridge_res)
 	                                               &sid_resource_type_worker_control,
 	                                               NULL))) {
 		log_error(ID(ubridge_res), INTERNAL_ERROR "%s: Failed to find worker control resource.", __func__);
-		NULL;
+		return NULL;
 	}
 
 	if (!(worker_proxy_res = worker_control_get_idle_worker(worker_control_res))) {
@@ -4178,7 +4178,7 @@ static sid_resource_t *_get_worker(sid_resource_t *ubridge_res)
 
 		if (!util_uuid_gen_str(&mem)) {
 			log_error(ID(ubridge_res), "Failed to generate UUID for new worker.");
-			NULL;
+			return NULL;
 		}
 
 		if (!(worker_proxy_res = worker_control_get_new_worker(worker_control_res, &((struct worker_params) {.id = uuid}))))


### PR DESCRIPTION
This patchset makes the worker process clean up the inherited resources before starting up the worker event loop.

Resolves #85, Resolves #108 