### PR TITLE
Add ability for kv store sync to rollback to previous state on failure.

### DIFF
--- a/src/base/buffer-type-linear.c
+++ b/src/base/buffer-type-linear.c
@@ -294,20 +294,20 @@ static bool _buffer_linear_is_complete(struct sid_buffer *buf, int *ret_code)
 	return result;
 }
 
-static int _buffer_linear_get_data(struct sid_buffer *buf, const void **data, size_t *data_size)
+static int _buffer_linear_get_data(struct sid_buffer *buf, size_t pos, const void **data, size_t *data_size)
 {
 	switch (buf->stat.spec.mode) {
 		case SID_BUFFER_MODE_PLAIN:
 			if (data)
-				*data = buf->mem;
+				*data = buf->mem + pos;
 			if (data_size)
-				*data_size = buf->stat.usage.used;
+				*data_size = buf->stat.usage.used - pos;
 			break;
 		case SID_BUFFER_MODE_SIZE_PREFIX:
 			if (data)
-				*data = buf->mem + SID_BUFFER_SIZE_PREFIX_LEN;
+				*data = buf->mem + SID_BUFFER_SIZE_PREFIX_LEN + pos;
 			if (data_size)
-				*data_size = (buf->stat.usage.used) ? buf->stat.usage.used - SID_BUFFER_SIZE_PREFIX_LEN : 0;
+				*data_size = (buf->stat.usage.used) ? buf->stat.usage.used - SID_BUFFER_SIZE_PREFIX_LEN - pos : 0;
 			break;
 		default:
 			return -ENOTSUP;

--- a/src/base/buffer-type-vector.c
+++ b/src/base/buffer-type-vector.c
@@ -278,20 +278,20 @@ static bool _buffer_vector_is_complete(struct sid_buffer *buf, int *ret_code)
 	return true;
 }
 
-static int _buffer_vector_get_data(struct sid_buffer *buf, const void **data, size_t *data_size)
+static int _buffer_vector_get_data(struct sid_buffer *buf, size_t pos, const void **data, size_t *data_size)
 {
 	switch (buf->stat.spec.mode) {
 		case SID_BUFFER_MODE_PLAIN:
 			if (data)
-				*data = buf->mem;
+				*data = buf->mem - (pos * VECTOR_ITEM_SIZE);
 			if (data_size)
-				*data_size = buf->stat.usage.used;
+				*data_size = buf->stat.usage.used - pos;
 			break;
 		case SID_BUFFER_MODE_SIZE_PREFIX:
 			if (data)
-				*data = buf->mem + VECTOR_ITEM_SIZE;
+				*data = buf->mem + (pos + 1) * VECTOR_ITEM_SIZE;
 			if (data_size)
-				*data_size = (buf->stat.usage.used) ? buf->stat.usage.used - 1 : 0;
+				*data_size = (buf->stat.usage.used) ? buf->stat.usage.used - pos - 1 : 0;
 			break;
 		default:
 			return -ENOTSUP;

--- a/src/base/buffer.c
+++ b/src/base/buffer.c
@@ -227,12 +227,22 @@ bool sid_buffer_is_complete(struct sid_buffer *buf, int *ret_code)
 	return _buffer_type_registry[buf->stat.spec.type]->is_complete(buf, ret_code);
 }
 
+int sid_buffer_get_data_from(struct sid_buffer *buf, size_t pos, const void **data, size_t *data_size)
+{
+	if (pos > sid_buffer_count(buf))
+		return -ERANGE;
+
+	if (!buf->mark.set || pos < buf->mark.set) {
+		buf->mark.set = true;
+		buf->mark.pos = pos;
+	}
+
+	return _buffer_type_registry[buf->stat.spec.type]->get_data(buf, pos, data, data_size);
+}
+
 int sid_buffer_get_data(struct sid_buffer *buf, const void **data, size_t *data_size)
 {
-	buf->mark.set = true;
-	buf->mark.pos = 0;
-
-	return _buffer_type_registry[buf->stat.spec.type]->get_data(buf, data, data_size);
+	return sid_buffer_get_data_from(buf, 0, data, data_size);
 }
 
 int sid_buffer_get_fd(struct sid_buffer *buf)

--- a/src/include/base/buffer-type.h
+++ b/src/include/base/buffer-type.h
@@ -44,7 +44,7 @@ struct sid_buffer_type {
 	int (*release)(struct sid_buffer *buf, size_t pos, bool rewind);
 	int (*release_mem)(struct sid_buffer *buf, const void *mem, bool rewind);
 	bool (*is_complete)(struct sid_buffer *buf, int *ret_code);
-	int (*get_data)(struct sid_buffer *buf, const void **data, size_t *data_size);
+	int (*get_data)(struct sid_buffer *buf, size_t pos, const void **data, size_t *data_size);
 	int (*get_fd)(struct sid_buffer *buf);
 	size_t (*count)(struct sid_buffer *buf);
 	ssize_t (*read)(struct sid_buffer *buf, int fd);

--- a/src/include/base/buffer.h
+++ b/src/include/base/buffer.h
@@ -49,6 +49,7 @@ int                    sid_buffer_rewind_mem(struct sid_buffer *buf, const void 
 bool                   sid_buffer_is_complete(struct sid_buffer *buf, int *ret_code);
 ssize_t                sid_buffer_read(struct sid_buffer *buf, int fd);
 ssize_t                sid_buffer_write(struct sid_buffer *buf, int fd, size_t pos);
+int                    sid_buffer_get_data_from(struct sid_buffer *buf, size_t pos, const void **data, size_t *data_size);
 int                    sid_buffer_get_data(struct sid_buffer *buf, const void **data, size_t *data_size);
 int                    sid_buffer_get_fd(struct sid_buffer *buf);
 size_t                 sid_buffer_count(struct sid_buffer *buf);

--- a/src/include/resource/kv-store.h
+++ b/src/include/resource/kv-store.h
@@ -167,6 +167,10 @@ int kv_store_unset(sid_resource_t *kv_store_res, const char *key, kv_store_updat
 
 size_t kv_store_get_size(sid_resource_t *kv_store_res, size_t *meta_size, size_t *data_size);
 
+int  kv_store_transaction_begin(sid_resource_t *kv_store_res);
+void kv_store_transaction_end(sid_resource_t *kv_store_res, bool rollback);
+bool kv_store_in_transaction(sid_resource_t *kv_store_res);
+
 typedef struct kv_store_iter kv_store_iter_t;
 
 kv_store_iter_t *kv_store_iter_create(sid_resource_t *kv_store_res, const char *key_start, const char *key_end);

--- a/src/resource/kv-store.c
+++ b/src/resource/kv-store.c
@@ -627,25 +627,21 @@ static bptree_update_action_t _bptree_unset_fn(const char *key,
 int kv_store_unset(sid_resource_t *kv_store_res, const char *key, kv_store_update_cb_fn_t kv_unset_fn, void *kv_unset_fn_arg)
 {
 	struct kv_store          *kv_store = sid_resource_get_data(kv_store_res);
-	struct kv_update_fn_relay relay    = {.kv_update_fn     = kv_unset_fn,
-	                                      .kv_update_fn_arg = kv_unset_fn_arg,
-	                                      .ret_code         = -EREMOTEIO};
+	struct kv_update_fn_relay relay    = {.kv_update_fn = kv_unset_fn, .kv_update_fn_arg = kv_unset_fn_arg};
 
 	key                                = _canonicalize_key(key);
 
 	switch (kv_store->backend) {
 		case KV_STORE_BACKEND_HASH:
-			if (hash_update(kv_store->ht, key, strlen(key) + 1, NULL, 0, _hash_unset_fn, &relay))
-				return -1;
+			hash_update(kv_store->ht, key, strlen(key) + 1, NULL, 0, _hash_unset_fn, &relay);
 			break;
 
 		case KV_STORE_BACKEND_BPTREE:
-			if (bptree_update(kv_store->bpt, key, NULL, 0, _bptree_unset_fn, &relay))
-				return -1;
+			bptree_update(kv_store->bpt, key, NULL, 0, _bptree_unset_fn, &relay);
 			break;
 	}
 
-	return 0;
+	return relay.ret_code;
 }
 
 kv_store_iter_t *kv_store_iter_create(sid_resource_t *kv_store_res, const char *key_start, const char *key_end)

--- a/src/resource/resource.c
+++ b/src/resource/resource.c
@@ -653,6 +653,9 @@ int sid_resource_create_signal_event_source(sid_resource_t                     *
 		goto fail;
 	}
 
+	if (prio && (r = sd_event_source_set_priority(sd_es, prio)) < 0)
+		goto fail;
+
 	if ((r = _create_event_source(res,
 	                              EVENT_SOURCE_SIGNAL,
 	                              name,
@@ -661,9 +664,6 @@ int sid_resource_create_signal_event_source(sid_resource_t                     *
 	                              data,
 	                              SID_RESOURCE_UNLIMITED_EVENT_COUNT,
 	                              es)) < 0)
-		goto fail;
-
-	if (prio && (r = sd_event_source_set_priority(sd_es, prio)) < 0)
 		goto fail;
 
 	return 0;

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -2342,7 +2342,7 @@ int _do_sid_ucmd_mod_reserve_kv(struct module              *mod,
 		flags |= (KV_SYNC | KV_PERSISTENT);
 
 	if (unset && !is_worker) {
-		if (kv_store_unset(common->kv_store_res, key, _kv_cb_write, &update_arg) < 0)
+		if (kv_store_unset(common->kv_store_res, key, _kv_cb_write, &update_arg) < 0 || update_arg.ret_code < 0)
 			goto out;
 	} else {
 		VVALUE_HEADER_PREP(vvalue, common->gennum, null_int, flags, (char *) owner);

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -733,9 +733,9 @@ static const char *_buffer_get_vvalue_str(struct sid_buffer *buf, bool unset, kv
 
 	if (sid_buffer_add(buf, "\0", 1, NULL, NULL) < 0)
 		goto fail;
-	sid_buffer_get_data(buf, (const void **) &str, NULL);
+	sid_buffer_get_data_from(buf, buf_offset, (const void **) &str, NULL);
 
-	return str + buf_offset;
+	return str;
 fail:
 	sid_buffer_rewind(buf, buf_offset, SID_BUFFER_POS_ABS);
 	return NULL;
@@ -3122,13 +3122,13 @@ static int _cmd_exec_resources(struct cmd_exec_arg *exec_arg)
 		               NULL,
 		               &buf_pos0);
 		sid_buffer_add(gen_buf, (void *) id, strlen(id) + 1, NULL, NULL);
-		sid_buffer_get_data(gen_buf, (const void **) &data, &size);
+		sid_buffer_get_data_from(gen_buf, buf_pos0, (const void **) &data, &size);
 
 		if ((r = worker_control_channel_send(exec_arg->cmd_res,
 		                                     MAIN_WORKER_CHANNEL_ID,
 		                                     &(struct worker_data_spec) {
-							     .data      = data + buf_pos0,
-							     .data_size = size - buf_pos0,
+							     .data      = data,
+							     .data_size = size,
 							     .ext.used  = false,
 						     })) < 0) {
 			log_error_errno(ID(exec_arg->cmd_res),
@@ -4184,12 +4184,12 @@ static int _send_out_cmd_expbuf(sid_resource_t *cmd_res)
 			               NULL,
 			               &buf_pos);
 			sid_buffer_add(buf, (void *) id, strlen(id) + 1, NULL, NULL);
-			sid_buffer_get_data(buf, (const void **) &data, &size);
+			sid_buffer_get_data_from(buf, buf_pos, (const void **) &data, &size);
 
 			if ((r = worker_control_channel_send(cmd_res,
 			                                     MAIN_WORKER_CHANNEL_ID,
-			                                     &(struct worker_data_spec) {.data               = data + buf_pos,
-			                                                                 .data_size          = size - buf_pos,
+			                                     &(struct worker_data_spec) {.data               = data,
+			                                                                 .data_size          = size,
 			                                                                 .ext.used           = true,
 			                                                                 .ext.socket.fd_pass = sid_buffer_get_fd(
 												 ucmd_ctx->exp_buf)})) < 0) {

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -4859,13 +4859,7 @@ static int _sync_main_kv_store(sid_resource_t *res, struct sid_ucmd_common_ctx *
 			update_arg.res   = common_ctx->kv_store_res;
 			update_arg.ret_code = -EREMOTEIO;
 
-			log_debug(ID(res),
-			          syncing_msg,
-			          key,
-			          unset         ? "NULL"
-			          : data_offset ? svalue->data + data_offset
-			                        : svalue->data,
-			          svalue->seqnum);
+			log_debug(ID(res), syncing_msg, key, unset ? "NULL" : svalue->data + data_offset, svalue->seqnum);
 
 			rel_spec.delta->op = KV_OP_SET;
 

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -1959,7 +1959,7 @@ static int _kv_cb_delta_step(struct kv_store_update_spec *spec)
 	if ((update_arg->ret_code = _check_kv_perms(update_arg, spec->key, spec->old_data, spec->new_data)) < 0)
 		return 0;
 
-	if (_delta_step_calc(spec) < 0)
+	if ((update_arg->ret_code = _delta_step_calc(spec)) < 0)
 		return 0;
 
 	if (rel_spec->delta->final) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,8 @@ check_PROGRAMS = \
 	test_bitmap \
 	test_iface \
 	test_internal \
-	test_bptree
+	test_bptree \
+	test_db_sync
 
 TESTS = $(check_PROGRAMS)
 test_buffer_SOURCES = test_buffer.c
@@ -43,5 +44,10 @@ test_internal_LDADD = $(top_builddir)/src/internal/libsidinternal.la \
 test_bptree_SOURCES = test_bptree.c
 test_bptree_LDADD = $(top_builddir)/src/internal/libsidinternal.la \
 		    $(top_builddir)/src/base/libsidbase.la -lcmocka
+test_db_sync_SOURCES = test_db_sync.c
+test_db_sync_CFLAGS = -I$(top_builddir)/src/include/resource
+test_db_sync_LDADD = \
+	$(top_builddir)/src/base/libsidbase.la \
+	$(top_builddir)/src/resource/libsidresource.la -lcmocka
 
 endif # HAVE_CMOCKA

--- a/tests/test_db_sync.c
+++ b/tests/test_db_sync.c
@@ -1,0 +1,707 @@
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdlib.h>
+/* define __USE_GNU for ucred definition */
+#define __USE_GNU
+#include "../src/internal/mem.c"
+#include "../src/resource/kv-store.c"
+#include "../src/resource/ubridge.c"
+#include "ucmd-module.h"
+
+#include <sys/socket.h>
+
+#include <cmocka.h>
+
+#define VALUE1 "baz"
+#define VALUE2 "quux"
+#define VALUE3 "xyzzy"
+#define VALUE4 "foobar"
+
+struct sid_ucmd_common_ctx *_create_common_ctx(void)
+{
+	struct sid_ucmd_common_ctx *common_ctx;
+
+	assert_non_null(common_ctx = mem_zalloc(sizeof(struct sid_ucmd_common_ctx)));
+	common_ctx->kv_store_res = sid_resource_create(SID_RESOURCE_NO_PARENT,
+	                                               &sid_resource_type_kv_store,
+	                                               SID_RESOURCE_RESTRICT_WALK_UP,
+	                                               "testkvstore",
+	                                               &main_kv_store_res_params,
+	                                               SID_RESOURCE_PRIO_NORMAL,
+	                                               SID_RESOURCE_NO_SERVICE_LINKS);
+	assert_non_null(common_ctx->kv_store_res);
+	common_ctx->gen_buf = sid_buffer_create(&((struct sid_buffer_spec) {.backend = SID_BUFFER_BACKEND_MALLOC,
+	                                                                    .type    = SID_BUFFER_TYPE_LINEAR,
+	                                                                    .mode    = SID_BUFFER_MODE_PLAIN}),
+	                                        &((struct sid_buffer_init) {.size = 0, .alloc_step = PATH_MAX, .limit = 0}),
+	                                        NULL);
+	assert_non_null(common_ctx->gen_buf);
+	common_ctx->gennum = 1;
+	return common_ctx;
+}
+
+void _destroy_common_ctx(struct sid_ucmd_common_ctx *common_ctx)
+{
+	sid_resource_unref(common_ctx->kv_store_res);
+	sid_buffer_destroy(common_ctx->gen_buf);
+	free(common_ctx);
+}
+
+static int _init_fake_command(sid_resource_t *res, const void *kickstart_data, void **data)
+{
+	struct sid_ucmd_ctx *ucmd_ctx;
+
+	assert_non_null(ucmd_ctx = mem_zalloc(sizeof(*ucmd_ctx)));
+	*data            = ucmd_ctx;
+	ucmd_ctx->common = _create_common_ctx();
+	return 0;
+}
+
+static int _destroy_fake_command(sid_resource_t *res)
+{
+	struct sid_ucmd_ctx *ucmd_ctx = sid_resource_get_data(res);
+
+	if (ucmd_ctx->exp_buf)
+		sid_buffer_destroy(ucmd_ctx->exp_buf);
+	_destroy_common_ctx(ucmd_ctx->common);
+	free(ucmd_ctx);
+	return 0;
+}
+
+const sid_resource_type_t sid_resource_type_fake_cmd = {
+	.name        = "fake_command",
+	.short_name  = "fake",
+	.description = "Fake ubridge command resource",
+	.init        = _init_fake_command,
+	.destroy     = _destroy_fake_command,
+};
+
+sid_resource_t *_create_fake_cmd_res(void)
+{
+	sid_resource_t *res;
+
+	res = sid_resource_create(SID_RESOURCE_NO_PARENT,
+	                          &sid_resource_type_fake_cmd,
+	                          SID_RESOURCE_NO_FLAGS,
+	                          "fakecmd",
+	                          SID_RESOURCE_NO_PARAMS,
+	                          SID_RESOURCE_PRIO_NORMAL,
+	                          SID_RESOURCE_NO_SERVICE_LINKS);
+	assert_non_null(res);
+	return res;
+}
+
+int _do_build_buffers(sid_resource_t *cmd_res)
+{
+	int                  fd;
+	struct sid_ucmd_ctx *ucmd_ctx = sid_resource_get_data(cmd_res);
+	struct cmd_reg       cmd_reg  = {.flags = CMD_KV_EXPBUF_TO_MAIN | CMD_KV_EXPORT_SID_TO_EXPBUF};
+
+	assert_int_equal(_build_cmd_kv_buffers(cmd_res, &cmd_reg), 0);
+	fd = sid_buffer_get_fd(ucmd_ctx->exp_buf);
+	assert_true(fd >= 0);
+	return fd;
+}
+
+struct kv_key_spec base_spec = {.op      = KV_OP_SET,
+                                .dom     = KV_KEY_DOM_USER,
+                                .ns      = KV_NS_GLOBAL,
+                                .ns_part = ID_NULL,
+                                .id_cat  = ID_NULL,
+                                .id      = ID_NULL,
+                                .core    = ID_NULL};
+
+static void _check_missing_kv(struct sid_ucmd_ctx *ucmd_ctx, const char *core)
+{
+	struct kv_key_spec     key_spec = base_spec;
+	char                  *key;
+	kv_store_value_flags_t flags;
+	size_t                 size;
+
+	key_spec.core = core;
+	assert_non_null(key = _compose_key(ucmd_ctx->common->gen_buf, &key_spec));
+	assert_null(kv_store_get_value(ucmd_ctx->common->kv_store_res, key, &size, &flags));
+
+	_destroy_key(ucmd_ctx->common->gen_buf, key);
+}
+
+static void _check_kv(struct sid_ucmd_ctx *ucmd_ctx, const char *core, char **data, size_t nr_data, bool vector)
+{
+	struct kv_key_spec     key_spec = base_spec;
+	char                  *key;
+	void                  *value;
+	kv_vector_t            tmp_vvalue[VVALUE_SINGLE_CNT];
+	kv_vector_t           *vvalue;
+	kv_store_value_flags_t flags;
+	size_t                 i, size;
+
+	key_spec.core = core;
+	assert_non_null(key = _compose_key(ucmd_ctx->common->gen_buf, &key_spec));
+
+	assert_non_null(value = kv_store_get_value(ucmd_ctx->common->kv_store_res, key, &size, &flags));
+	vvalue = _get_vvalue(flags, value, size, tmp_vvalue);
+	if (flags & KV_STORE_VALUE_VECTOR) {
+		assert_true(vector);
+	} else {
+		assert_false(vector);
+		size = vvalue[VVALUE_IDX_DATA].iov_len ? VVALUE_SINGLE_CNT : VVALUE_HEADER_CNT;
+	}
+	assert_int_equal(nr_data, size - VVALUE_HEADER_CNT);
+
+	for (i = 0; i < nr_data; i++) {
+		if (!data[i])
+			assert_null(vvalue[VVALUE_IDX_DATA + i].iov_base);
+		else
+			assert_string_equal(vvalue[VVALUE_IDX_DATA + i].iov_base, data[i]);
+	}
+
+	_destroy_key(ucmd_ctx->common->gen_buf, key);
+}
+
+static void _set_kv(struct sid_ucmd_ctx *ucmd_ctx, const char *core, char **data, size_t nr_data, kv_op_t op, bool vector)
+{
+	const char          *owner    = _get_mod_name(NULL);
+	struct kv_key_spec   key_spec = base_spec;
+	char                *key;
+	kv_vector_t          vvalue[VVALUE_HEADER_CNT + nr_data];
+	sid_ucmd_kv_flags_t  flags      = KV_RD;
+	struct kv_update_arg update_arg = {.res      = ucmd_ctx->common->kv_store_res,
+	                                   .owner    = owner,
+	                                   .gen_buf  = ucmd_ctx->common->gen_buf,
+	                                   .custom   = NULL,
+	                                   .ret_code = -EREMOTEIO};
+	size_t               i;
+
+	key_spec.op   = op;
+	key_spec.core = core;
+	assert_non_null(key = _compose_key(ucmd_ctx->common->gen_buf, &key_spec));
+
+	VVALUE_HEADER_PREP(vvalue, ucmd_ctx->common->gennum, ucmd_ctx->req_env.dev.udev.seqnum, flags, (char *) owner);
+	for (i = 0; i < nr_data; i++)
+		VVALUE_DATA_PREP(vvalue, i, data[i], data[i] ? strlen(data[i]) + 1 : 0);
+
+	assert_non_null(kv_store_set_value(ucmd_ctx->common->kv_store_res,
+	                                   key,
+	                                   vvalue,
+	                                   VVALUE_HEADER_CNT + nr_data,
+	                                   KV_STORE_VALUE_VECTOR,
+	                                   vector ? KV_STORE_VALUE_NO_OP : KV_STORE_VALUE_OP_MERGE,
+	                                   _kv_cb_write,
+	                                   &update_arg));
+	assert_true(update_arg.ret_code >= 0);
+
+	_destroy_key(ucmd_ctx->common->gen_buf, key);
+}
+
+static void _set_broken_kv(struct sid_ucmd_ctx *ucmd_ctx, const char *core)
+{
+	const char          *owner    = _get_mod_name(NULL);
+	struct kv_key_spec   key_spec = base_spec;
+	char                *key;
+	kv_vector_t          vvalue[VVALUE_HEADER_CNT];
+	sid_ucmd_kv_flags_t  flags      = KV_RD;
+	struct kv_update_arg update_arg = {.res      = ucmd_ctx->common->kv_store_res,
+	                                   .owner    = owner,
+	                                   .gen_buf  = ucmd_ctx->common->gen_buf,
+	                                   .custom   = NULL,
+	                                   .ret_code = -EREMOTEIO};
+
+	key_spec.core                   = core;
+	assert_non_null(key = _compose_key(ucmd_ctx->common->gen_buf, &key_spec));
+
+	VVALUE_HEADER_PREP(vvalue, ucmd_ctx->common->gennum, ucmd_ctx->req_env.dev.udev.seqnum, flags, (char *) owner);
+	assert_non_null(kv_store_set_value(ucmd_ctx->common->kv_store_res,
+	                                   key,
+	                                   vvalue,
+	                                   VVALUE_HEADER_CNT - 1,
+	                                   KV_STORE_VALUE_VECTOR,
+	                                   KV_STORE_VALUE_NO_OP,
+	                                   NULL,
+	                                   &update_arg));
+
+	_destroy_key(ucmd_ctx->common->gen_buf, key);
+}
+
+#define ARRAY_LEN(array) (sizeof((array)) / sizeof((array)[0]))
+
+struct test_state {
+	sid_resource_t      *work_res;
+	sid_resource_t      *main_res;
+	struct sid_ucmd_ctx *work_ctx;
+	struct sid_ucmd_ctx *main_ctx;
+};
+
+static void dumper_fn(const char *key, void *value, size_t size, unsigned ref_count, void *arg)
+{
+	struct sid_buffer *buf = arg;
+
+	assert_int_equal(sid_buffer_add(buf, (void *) key, strlen(key) + 1, NULL, NULL), 0);
+	assert_int_equal(sid_buffer_add(buf, value, size, NULL, NULL), 0);
+}
+
+static struct sid_buffer *dump_db(sid_resource_t *kv_store_res)
+{
+	struct kv_store *kv_store = sid_resource_get_data(kv_store_res);
+	/* Could do this for hash as well but not sure if it's worth is */
+	assert_true(kv_store->backend == KV_STORE_BACKEND_BPTREE);
+	struct sid_buffer *buf = sid_buffer_create(&((struct sid_buffer_spec) {.backend = SID_BUFFER_BACKEND_MALLOC,
+	                                                                       .type    = SID_BUFFER_TYPE_VECTOR,
+	                                                                       .mode    = SID_BUFFER_MODE_PLAIN}),
+	                                           &((struct sid_buffer_init) {.size = 0, .alloc_step = 2, .limit = 0}),
+	                                           NULL);
+	assert_non_null(buf);
+	bptree_iter(kv_store->bpt, NULL, NULL, dumper_fn, buf);
+	return buf;
+}
+
+static void compare_dumps(struct sid_buffer *old_dump, struct sid_buffer *new_dump)
+{
+	kv_vector_t *new, *old;
+	size_t new_size, old_size, i;
+
+	assert_int_equal(sid_buffer_get_data(old_dump, (const void **) &old, &old_size), 0);
+	assert_int_equal(sid_buffer_get_data(new_dump, (const void **) &new, &new_size), 0);
+	assert_true(old_size == new_size);
+	assert_true(old_size % 2 == 0);
+	for (i = 0; i < old_size; i++) {
+		assert_ptr_equal(old[i].iov_base, new[i].iov_base);
+		assert_int_equal(old[i].iov_len, new[i].iov_len);
+	}
+	sid_buffer_destroy(old_dump);
+	sid_buffer_destroy(new_dump);
+}
+
+static void test_scalar(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {"value"};
+
+	_set_kv(ts->work_ctx, "key", data, ARRAY_LEN(data), KV_OP_SET, false);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", data, ARRAY_LEN(data), false);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_vector(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3};
+
+	_set_kv(ts->work_ctx, "key", data, ARRAY_LEN(data), KV_OP_SET, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", data, ARRAY_LEN(data), true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_unset_scalar(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {"value"};
+
+	_set_kv(ts->main_ctx, "key", data, ARRAY_LEN(data), KV_OP_SET, false);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key", NULL, 0, KV_OP_SET, false);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_missing_kv(ts->main_ctx, "key");
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 0);
+}
+
+static void test_unset_vector(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2};
+
+	_set_kv(ts->main_ctx, "key", data, ARRAY_LEN(data), KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key", NULL, 0, KV_OP_SET, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_missing_kv(ts->main_ctx, "key");
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 0);
+}
+
+static void test_unset_missing(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {"value"};
+
+	_set_kv(ts->work_ctx, "key", NULL, 0, KV_OP_SET, false);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_missing_kv(ts->main_ctx, "key");
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 0);
+}
+
+static void test_subtract_missing(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {"value"};
+
+	_set_kv(ts->work_ctx, "key", data, 1, KV_OP_MINUS, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", NULL, 0, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_add_missing(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {"value"};
+
+	_set_kv(ts->work_ctx, "key", data, 1, KV_OP_PLUS, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", data, 1, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_vector_subtract(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3};
+
+	_set_kv(ts->main_ctx, "key", data, ARRAY_LEN(data), KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key", data, 2, KV_OP_MINUS, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", &data[2], 1, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_vector_add(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2};
+
+	_set_kv(ts->main_ctx, "key", data, 1, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key", &data[1], 1, KV_OP_PLUS, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", data, ARRAY_LEN(data), true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_vector_change(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3, VALUE4};
+
+	_set_kv(ts->main_ctx, "key", &data[1], 2, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key", data, ARRAY_LEN(data), KV_OP_SET, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", data, ARRAY_LEN(data), true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_scalar_change(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data1[] = {VALUE1};
+	char              *data2[] = {VALUE2};
+
+	_set_kv(ts->main_ctx, "key", data1, ARRAY_LEN(data1), KV_OP_SET, false);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key", data2, ARRAY_LEN(data2), KV_OP_SET, false);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", data2, ARRAY_LEN(data2), false);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_type_change1(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3, VALUE4};
+
+	_set_kv(ts->main_ctx, "key", &data[2], 1, KV_OP_SET, false);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key", data, ARRAY_LEN(data), KV_OP_SET, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", data, ARRAY_LEN(data), true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_type_change2(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3, VALUE4};
+
+	_set_kv(ts->main_ctx, "key", &data[1], 3, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key", data, 1, KV_OP_SET, false);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key", data, 1, false);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+}
+
+static void test_empty_broken(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+
+	_set_broken_kv(ts->work_ctx, "key");
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 0);
+}
+
+static void test_set_broken(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1};
+
+	_set_kv(ts->work_ctx, "key1", data, ARRAY_LEN(data), KV_OP_SET, false);
+	_set_broken_kv(ts->work_ctx, "key2");
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 0);
+}
+
+static void test_unset_broken(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2};
+	struct sid_buffer *old, *new;
+
+	_set_kv(ts->main_ctx, "key1", data, ARRAY_LEN(data), KV_OP_SET, true);
+	_set_kv(ts->work_ctx, "key1", NULL, 0, KV_OP_SET, true);
+	_set_broken_kv(ts->work_ctx, "key2");
+	fd  = _do_build_buffers(ts->work_res);
+	old = dump_db(ts->main_ctx->common->kv_store_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	new = dump_db(ts->main_ctx->common->kv_store_res);
+	compare_dumps(old, new);
+}
+
+static void test_change_broken(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2};
+	struct sid_buffer *old, *new;
+
+	_set_kv(ts->main_ctx, "key1", &data[0], 1, KV_OP_SET, false);
+	_set_kv(ts->work_ctx, "key1", &data[1], 1, KV_OP_SET, false);
+	_set_broken_kv(ts->work_ctx, "key2");
+	fd  = _do_build_buffers(ts->work_res);
+	old = dump_db(ts->main_ctx->common->kv_store_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	new = dump_db(ts->main_ctx->common->kv_store_res);
+	compare_dumps(old, new);
+}
+
+static void test_subtract_broken(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3};
+	struct sid_buffer *old, *new;
+
+	_set_kv(ts->main_ctx, "key1", data, ARRAY_LEN(data), KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key1", data, 2, KV_OP_MINUS, true);
+	_set_broken_kv(ts->work_ctx, "key2");
+	fd  = _do_build_buffers(ts->work_res);
+	old = dump_db(ts->main_ctx->common->kv_store_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	new = dump_db(ts->main_ctx->common->kv_store_res);
+	compare_dumps(old, new);
+}
+
+static void test_add_broken(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2};
+	struct sid_buffer *old, *new;
+
+	_set_kv(ts->main_ctx, "key1", data, 1, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 1);
+	_set_kv(ts->work_ctx, "key1", &data[1], 1, KV_OP_PLUS, true);
+	_set_broken_kv(ts->work_ctx, "key2");
+	fd  = _do_build_buffers(ts->work_res);
+	old = dump_db(ts->main_ctx->common->kv_store_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	new = dump_db(ts->main_ctx->common->kv_store_res);
+	compare_dumps(old, new);
+}
+
+static void test_multi_1(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3, VALUE4};
+
+	_set_kv(ts->main_ctx, "key1", &data[1], 2, KV_OP_SET, true);
+	_set_kv(ts->main_ctx, "key2", &data[2], 1, KV_OP_SET, false);
+	_set_kv(ts->main_ctx, "key3", data, 3, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 3);
+	_set_kv(ts->work_ctx, "key1", &data[2], 1, KV_OP_MINUS, true);
+	_set_kv(ts->work_ctx, "key3", &data[2], 2, KV_OP_PLUS, true);
+	_set_kv(ts->work_ctx, "key2", NULL, 0, KV_OP_SET, false);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key1", &data[1], 1, true);
+	_check_kv(ts->main_ctx, "key3", data, ARRAY_LEN(data), true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 2);
+}
+
+static void test_multi_broken_1(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3, VALUE4};
+	struct sid_buffer *old, *new;
+
+	_set_kv(ts->main_ctx, "key1", &data[1], 2, KV_OP_SET, true);
+	_set_kv(ts->main_ctx, "key2", &data[2], 1, KV_OP_SET, false);
+	_set_kv(ts->main_ctx, "key3", data, 3, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 3);
+	_set_kv(ts->work_ctx, "key1", &data[2], 1, KV_OP_MINUS, true);
+	_set_kv(ts->work_ctx, "key3", &data[2], 2, KV_OP_PLUS, true);
+	_set_kv(ts->work_ctx, "key2", NULL, 0, KV_OP_SET, false);
+	_set_broken_kv(ts->work_ctx, "key4");
+	fd  = _do_build_buffers(ts->work_res);
+	old = dump_db(ts->main_ctx->common->kv_store_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	new = dump_db(ts->main_ctx->common->kv_store_res);
+	compare_dumps(old, new);
+}
+
+static void test_multi_2(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3, VALUE4};
+
+	_set_kv(ts->main_ctx, "key1", &data[1], 2, KV_OP_SET, true);
+	_set_kv(ts->main_ctx, "key2", &data[2], 1, KV_OP_SET, false);
+	_set_kv(ts->main_ctx, "key3", data, 4, KV_OP_SET, true);
+	_set_kv(ts->main_ctx, "key4", &data[3], 1, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 4);
+	_set_kv(ts->work_ctx, "key1", &data[2], 1, KV_OP_SET, false);
+	_set_kv(ts->work_ctx, "key2", NULL, 0, KV_OP_SET, false);
+	_set_kv(ts->work_ctx, "key4", data, 1, KV_OP_MINUS, true);
+	_set_kv(ts->work_ctx, "key5", &data[1], 3, KV_OP_SET, true);
+	fd = _do_build_buffers(ts->work_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), 0);
+	_check_kv(ts->main_ctx, "key1", &data[2], 1, false);
+	_check_kv(ts->main_ctx, "key3", data, 4, true);
+	_check_kv(ts->main_ctx, "key4", &data[3], 1, true);
+	_check_kv(ts->main_ctx, "key5", &data[1], 3, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 4);
+}
+
+static void test_multi_broken_2(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3, VALUE4};
+	struct sid_buffer *old, *new;
+
+	_set_kv(ts->main_ctx, "key1", &data[1], 2, KV_OP_SET, true);
+	_set_kv(ts->main_ctx, "key2", &data[2], 1, KV_OP_SET, false);
+	_set_kv(ts->main_ctx, "key3", data, 4, KV_OP_SET, true);
+	_set_kv(ts->main_ctx, "key4", &data[3], 1, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 4);
+	_set_kv(ts->work_ctx, "key1", &data[2], 1, KV_OP_SET, false);
+	_set_kv(ts->work_ctx, "key2", NULL, 0, KV_OP_SET, false);
+	_set_kv(ts->work_ctx, "key4", data, 1, KV_OP_MINUS, true);
+	_set_kv(ts->work_ctx, "key5", &data[1], 3, KV_OP_SET, true);
+	_set_broken_kv(ts->work_ctx, "key6");
+	fd  = _do_build_buffers(ts->work_res);
+	old = dump_db(ts->main_ctx->common->kv_store_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	new = dump_db(ts->main_ctx->common->kv_store_res);
+	compare_dumps(old, new);
+}
+
+static void test_multi_broken_3(void **state)
+{
+	struct test_state *ts = *state;
+	int                fd;
+	char              *data[] = {VALUE1, VALUE2, VALUE3, VALUE4};
+	struct sid_buffer *old, *new;
+
+	_set_kv(ts->main_ctx, "key1", &data[1], 2, KV_OP_SET, true);
+	_set_kv(ts->main_ctx, "key2", &data[2], 1, KV_OP_SET, false);
+	_set_kv(ts->main_ctx, "key4", data, 4, KV_OP_SET, true);
+	_set_kv(ts->main_ctx, "key5", &data[3], 1, KV_OP_SET, true);
+	assert_int_equal(kv_store_num_entries(ts->main_ctx->common->kv_store_res), 4);
+	_set_kv(ts->work_ctx, "key1", &data[2], 1, KV_OP_SET, false);
+	_set_kv(ts->work_ctx, "key2", NULL, 0, KV_OP_SET, false);
+	_set_broken_kv(ts->work_ctx, "key3");
+	_set_kv(ts->work_ctx, "key5", data, 1, KV_OP_MINUS, true);
+	_set_kv(ts->work_ctx, "key6", &data[1], 3, KV_OP_SET, true);
+	fd  = _do_build_buffers(ts->work_res);
+	old = dump_db(ts->main_ctx->common->kv_store_res);
+	assert_int_equal(_sync_main_kv_store(ts->main_res, ts->main_ctx->common, fd), -1);
+	new = dump_db(ts->main_ctx->common->kv_store_res);
+	compare_dumps(old, new);
+}
+
+int setup(void **state)
+{
+	struct test_state *ts = malloc(sizeof(struct test_state));
+
+	assert_non_null(ts);
+	ts->work_res = _create_fake_cmd_res();
+	ts->main_res = _create_fake_cmd_res();
+	ts->work_ctx = sid_resource_get_data(ts->work_res);
+	ts->main_ctx = sid_resource_get_data(ts->main_res);
+	*state       = ts;
+	return 0;
+}
+
+int teardown(void **state)
+{
+	struct test_state *ts = *state;
+	sid_resource_unref(ts->work_res);
+	sid_resource_unref(ts->main_res);
+	free(ts);
+	return 0;
+}
+
+#define setup_test(func) cmocka_unit_test_setup_teardown((func), setup, teardown)
+
+int main(void)
+{
+	cmocka_set_message_output(CM_OUTPUT_STDOUT);
+	const struct CMUnitTest tests[] = {
+		setup_test(test_scalar),        setup_test(test_vector),           setup_test(test_unset_scalar),
+		setup_test(test_unset_vector),  setup_test(test_unset_missing),    setup_test(test_vector_subtract),
+		setup_test(test_vector_add),    setup_test(test_subtract_missing), setup_test(test_add_missing),
+		setup_test(test_vector_change), setup_test(test_scalar_change),    setup_test(test_type_change1),
+		setup_test(test_type_change2),  setup_test(test_empty_broken),     setup_test(test_set_broken),
+		setup_test(test_unset_broken),  setup_test(test_change_broken),    setup_test(test_subtract_broken),
+		setup_test(test_add_broken),    setup_test(test_multi_1),          setup_test(test_multi_broken_1),
+		setup_test(test_multi_2),       setup_test(test_multi_broken_2),   setup_test(test_multi_broken_3),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_kv_store.c
+++ b/tests/test_kv_store.c
@@ -158,7 +158,9 @@ static void test_kvstore_iterate(void **state)
 
 	assert_int_equal(kv_store_num_entries(kv_store_res), 1);
 	/* TODO: if update_arg is NULL in the following call it causes SEGV */
+	update_arg.ret_code = 0;
 	assert_int_equal(kv_store_unset(kv_store_res, TEST_KEY, _kv_cb_main_unset, &update_arg), 0);
+	assert_int_equal(update_arg.ret_code, 0);
 	assert_int_equal(kv_store_num_entries(kv_store_res), 0);
 	kv_store_get_size(kv_store_res, &meta_size, &data_size);
 	assert_int_equal(data_size, 0);


### PR DESCRIPTION
_sync_main_kv_store() can now rollback if it encounters a failure syncing the kv store. Since unsetting an entry cannot fail, it delays performing these actions until it has already performed the ones that can fail.  For actions that can fail (setting, adding and removing), the kv callbacks now have access to an opaque pointer to the current kv_store_value.  They save this value instead of destroying it. If all the the actions succeed, the saved values are destroyed.  Otherwise, the saved values are used to rollback to state of the database. The new value is destroyed and depending on whether the saved value was NULL or not, the entry is either removed, or it's value is replaced by the saved value. Neither of these actions can fail.  It is possible that the old value was saved, but the entry was never updated.  In this case, the new and saved values will be the same during rollback, and nothing is done. The end result is that it is always possible to revert the state of the database while only calling functions that do not fail.

There are unit tests for this code, but they trigger the rollbacks by writing an invalid entry to worker kv store. This means that the code to deal with failures in updating the entry is not tested.  It's probably possible with some fancy mocking of the allocation code.