### PR TITLE
Various RPM build related fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,3 +19,5 @@
 
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src udev systemd man . tests
+
+EXTRA_DIST = BSD_LICENSE

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ AC_CONFIG_FILES([Makefile
 		 udev/Makefile
 		 systemd/Makefile
 		 man/Makefile
+		 man/sid.8
 		 tests/Makefile])
 
 AC_CONFIG_HEADERS([src/include/config.h])

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -19,8 +19,5 @@
 
 dist_man8_MANS = sid.8
 
-$(dist_man8_MANS):%:%.in
-	$(SED) -e "s|(VERSION)|$(VERSION)|" $< >$@
-
 distclean-local:
 	$(RM) $(dist_man8_MANS)

--- a/man/sid.8.in
+++ b/man/sid.8.in
@@ -1,4 +1,4 @@
-.TH SID 8 "Storage Instantiation Daemon version (VERSION)" "Red Hat, Inc."
+.TH SID 8 "Storage Instantiation Daemon version @VERSION@" "Red Hat, Inc."
 .
 .SH NAME
 .

--- a/rpm/sid.spec
+++ b/rpm/sid.spec
@@ -163,6 +163,28 @@ functions.
 %doc README.md
 
 ##############################################################################
+# SID-INTERNAL-LIBS-DEVEL
+##############################################################################
+%package internal-libs-devel
+Summary: Development files for Storage Instantiation Daemon (SID) internal
+License: GPL-2.0-or-later AND BSD-3-Clause
+%description internal-libs-devel
+This package contains development files for Storage Instantiation Daemon (SID)
+internal libraries.
+
+%files internal-libs-devel
+%dir %{_includedir}/sid/internal
+%{_includedir}/sid/internal/bitmap.h
+%{_includedir}/sid/internal/bptree.h
+%{_includedir}/sid/internal/common.h
+%{_includedir}/sid/internal/formatter.h
+%{_includedir}/sid/internal/hash.h
+%{_includedir}/sid/internal/list.h
+%{_includedir}/sid/internal/mem.h
+%{_includedir}/sid/internal/util.h
+%{_libdir}/sid/libsidinternal.so
+
+##############################################################################
 # SID-LOG-LIBS
 ##############################################################################
 

--- a/rpm/sid.spec
+++ b/rpm/sid.spec
@@ -67,7 +67,7 @@ of devices and their layers in the stack.
 %endif
 
 %build
-./autogen.sh
+autoreconf -ivf
 %configure %{?configure_dm_mpath}
 %make_build
 

--- a/rpm/sid.spec
+++ b/rpm/sid.spec
@@ -136,8 +136,8 @@ base libraries.
 %dir %{_includedir}/sid/base
 %{_includedir}/sid/base/binary.h
 %{_includedir}/sid/base/buffer-common.h
+%{_includedir}/sid/base/buffer-type.h
 %{_includedir}/sid/base/buffer.h
-%{_includedir}/sid/base/common.h
 %{_includedir}/sid/base/comms.h
 %{_includedir}/sid/base/util.h
 %doc README.md
@@ -238,6 +238,7 @@ interface libraries.
 %dir %{_includedir}/sid/iface
 %{_includedir}/sid/iface/service-link.h
 %{_includedir}/sid/iface/iface.h
+%{_includedir}/sid/iface/iface_internal.h
 %doc README.md
 
 

--- a/rpm/sid.spec
+++ b/rpm/sid.spec
@@ -76,6 +76,7 @@ make DESTDIR=%{buildroot} install
 rm -f %{buildroot}/%{_libdir}/sid/*.{a,la}
 rm -f %{buildroot}/%{_libdir}/sid/modules/ucmd/block/*.{a,la}
 rm -f %{buildroot}/%{_libdir}/sid/modules/ucmd/type/*.{a,la}
+rm -f %{buildroot}/%{_libdir}/sid/modules/ucmd/type/dm/*.{a,la}
 %multilib_fix_c_header --file %{_includedir}/sid/config.h
 
 %files
@@ -403,6 +404,23 @@ Daemon (SID).
 %dir %{_libdir}/sid/modules/ucmd/type
 %dir %{_libdir}/sid/modules/ucmd/type/dm
 %{_libdir}/sid/modules/ucmd/type/dm.so
+%doc README.md
+
+##############################################################################
+# SID-MOD-TYPE-DM-LVM
+##############################################################################
+
+%package mod-type-dm-lvm
+Summary: LVM type module for Storage Instantiation Daemon (SID)
+Requires: %{name}-log-libs%{?_isa} = %{?epoch}:%{version}-%{release}
+Requires: %{name}-resource-libs%{?_isa} = %{?epoch}:%{version}-%{release}
+Requires: %{name}-mod-type-dm%{?_isa} = %{?epoch}:%{version}-%{release}
+%description mod-type-dm-lvm
+This package contains LVM type module for Storage Instantiation
+Daemon (SID).
+
+%files mod-type-dm-lvm
+%{_libdir}/sid/modules/ucmd/type/dm/lvm.so
 %doc README.md
 
 

--- a/src/base/Makefile.am
+++ b/src/base/Makefile.am
@@ -19,8 +19,7 @@
 
 pkglib_LTLIBRARIES = libsidbase.la
 
-libsidbase_la_SOURCES = buffer-type.h \
-			buffer-type-linear.c \
+libsidbase_la_SOURCES = buffer-type-linear.c \
 			buffer-type-vector.c \
 			buffer.c \
 			comms.c \
@@ -30,6 +29,7 @@ libsidbase_la_SOURCES = buffer-type.h \
 basedir = $(pkgincludedir)/base
 
 base_HEADERS = $(top_builddir)/src/include/base/buffer-common.h \
+	       $(top_builddir)/src/include/base/buffer-type.h \
 	       $(top_builddir)/src/include/base/buffer.h \
 	       $(top_builddir)/src/include/base/comms.h \
 	       $(top_builddir)/src/include/base/util.h \

--- a/src/iface/Makefile.am
+++ b/src/iface/Makefile.am
@@ -39,7 +39,8 @@ libsidiface_la_SOURCES = iface.c
 
 libsidiface_la_LIBADD = $(top_builddir)/src/base/libsidbase.la
 
-iface_HEADERS = $(top_builddir)/src/include/iface/iface.h
+iface_HEADERS = $(top_builddir)/src/include/iface/iface.h \
+		$(top_builddir)/src/include/iface/iface_internal.h
 
 libsidiface_la_LDFLAGS = -version-info 0:0:0
 

--- a/src/modules/ucmd/type/dm/Makefile.am
+++ b/src/modules/ucmd/type/dm/Makefile.am
@@ -23,7 +23,7 @@ dmdir = $(pkglibdir)/modules/ucmd/type
 
 dm_LTLIBRARIES = dm.la
 
-dm_la_SOURCES = dm.c
+dm_la_SOURCES = dm.c dm.h
 
 dm_la_LDFLAGS = -module -avoid-version
 

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -33,3 +33,7 @@ $(dist_sysconfig_DATA):%:%.in
 distclean-local:
 	$(RM) $(dist_systemdsystemunit_DATA) \
 		$(dist_sysconfig_DATA)
+
+EXTRA_DIST = sid.socket.in \
+	     sid.service.in \
+	     sid.sysconfig.in


### PR DESCRIPTION
I am not really sure if all the autotools related changes are correct, but `make dist` and `rpmbuild` seems to be working now.