### PR TITLE
resource: kv-store: add kv_store_set_value_with_archive

### DIFF
--- a/src/include/resource/kv-store.h
+++ b/src/include/resource/kv-store.h
@@ -137,6 +137,16 @@ void *kv_store_set_value(sid_resource_t           *kv_store_res,
                          kv_store_update_cb_fn_t   kv_update_fn,
                          void                     *kv_update_fn_arg);
 
+void *kv_store_set_value_with_archive(sid_resource_t           *kv_store_res,
+                                      const char               *key,
+                                      void                     *value,
+                                      size_t                    value_size,
+                                      kv_store_value_flags_t    flags,
+                                      kv_store_value_op_flags_t op_flags,
+                                      kv_store_update_cb_fn_t   kv_update_fn,
+                                      void                     *kv_update_fn_arg,
+                                      const char               *archive_key);
+
 /*
  * Add alias for given key.
  *   - if the alias is already used and is pointing to a different record

--- a/src/include/resource/ucmd-module.h
+++ b/src/include/resource/ucmd-module.h
@@ -165,6 +165,8 @@ typedef enum {
 	KV_SUBMOD_WR       = UINT64_C(0x0000000000000080),
 	KV_WR              = UINT64_C(0x00000000000000C0),
 
+	KV_ARCHIVE         = UINT64_C(0x0000000000000100),
+
 	_KV_ENUM_SIZE      = UINT64_C(0x7fffffffffffffff), /* used to force the enum to 64 bits */
 } sid_ucmd_kv_flags_t;
 

--- a/src/include/resource/ucmd-module.h
+++ b/src/include/resource/ucmd-module.h
@@ -186,7 +186,8 @@ const void *sid_ucmd_get_kv(struct module          *mod,
                             sid_ucmd_kv_namespace_t ns,
                             const char             *key,
                             size_t                 *value_size,
-                            sid_ucmd_kv_flags_t    *flags);
+                            sid_ucmd_kv_flags_t    *flags,
+                            unsigned int            archive);
 
 const void *sid_ucmd_get_foreign_mod_kv(struct module          *mod,
                                         struct sid_ucmd_ctx    *ucmd_ctx,
@@ -194,7 +195,8 @@ const void *sid_ucmd_get_foreign_mod_kv(struct module          *mod,
                                         sid_ucmd_kv_namespace_t ns,
                                         const char             *key,
                                         size_t                 *value_size,
-                                        sid_ucmd_kv_flags_t    *flags);
+                                        sid_ucmd_kv_flags_t    *flags,
+                                        unsigned int            archive);
 
 const void *sid_ucmd_get_foreign_dev_kv(struct module          *mod,
                                         struct sid_ucmd_ctx    *ucmd_ctx,
@@ -202,7 +204,8 @@ const void *sid_ucmd_get_foreign_dev_kv(struct module          *mod,
                                         sid_ucmd_kv_namespace_t ns,
                                         const char             *key,
                                         size_t                 *value_size,
-                                        sid_ucmd_kv_flags_t    *flags);
+                                        sid_ucmd_kv_flags_t    *flags,
+                                        unsigned int            archive);
 
 const void *sid_ucmd_get_foreign_dev_mod_kv(struct module          *mod,
                                             struct sid_ucmd_ctx    *ucmd_ctx,
@@ -211,7 +214,8 @@ const void *sid_ucmd_get_foreign_dev_mod_kv(struct module          *mod,
                                             sid_ucmd_kv_namespace_t ns,
                                             const char             *key,
                                             size_t                 *value_size,
-                                            sid_ucmd_kv_flags_t    *flags);
+                                            sid_ucmd_kv_flags_t    *flags,
+                                            unsigned int            archive);
 
 const void *sid_ucmd_part_get_disk_kv(struct module       *mod,
                                       struct sid_ucmd_ctx *ucmd_ctx,

--- a/src/modules/ucmd/block/dm_mpath/dm_mpath.c
+++ b/src/modules/ucmd/block/dm_mpath/dm_mpath.c
@@ -142,7 +142,7 @@ static int _dm_mpath_scan_next(struct module *module, struct sid_ucmd_ctx *ucmd_
 		char       *p;
 		int         old_valid;
 
-		old_valid_str = sid_ucmd_get_kv(module, ucmd_ctx, KV_NS_DEVMOD, X_VALID, NULL, NULL);
+		old_valid_str = sid_ucmd_get_kv(module, ucmd_ctx, KV_NS_DEVMOD, X_VALID, NULL, NULL, 0);
 		if (old_valid_str && old_valid_str[0]) {
 			errno     = 0;
 			old_valid = strtol(old_valid_str, &p, 10);

--- a/src/modules/ucmd/type/dm/dm.c
+++ b/src/modules/ucmd/type/dm/dm.c
@@ -180,7 +180,7 @@ static int _dm_ident(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
 	sid_ucmd_set_kv(module, ucmd_ctx, KV_NS_DEVMOD, "name", name, strlen(name) + 1, KV_SYNC | KV_SUBMOD_RD);
 
 	dm_mod      = module_get_data(module);
-	submod_name = sid_ucmd_get_kv(module, ucmd_ctx, KV_NS_DEVICE, DM_SUBMODULES_ID, NULL, NULL);
+	submod_name = sid_ucmd_get_kv(module, ucmd_ctx, KV_NS_DEVICE, DM_SUBMODULES_ID, NULL, NULL, 0);
 
 	if (submod_name) {
 		if (strcmp(submod_name, DM_SUBMODULE_ID_NONE) != 0) {
@@ -279,7 +279,7 @@ static int _dm_scan_next(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
 
 	log_debug(DM_ID, "scan-next");
 
-	if ((val = sid_ucmd_get_kv(module, ucmd_ctx, KV_NS_UDEV, "ID_FS_TYPE", NULL, NULL))) {
+	if ((val = sid_ucmd_get_kv(module, ucmd_ctx, KV_NS_UDEV, "ID_FS_TYPE", NULL, NULL, 0))) {
 		if (!strcmp(val, "LVM2_member") || !strcmp(val, "LVM1_member"))
 			submod_name = "lvm";
 		else if (!strcmp(val, "DM_snapshot_cow"))

--- a/src/modules/ucmd/type/dm/lvm/lvm.c
+++ b/src/modules/ucmd/type/dm/lvm/lvm.c
@@ -55,7 +55,7 @@ static int _lvm_subsys_match(struct module *module, struct sid_ucmd_ctx *ucmd_ct
 {
 	const char *uuid;
 
-	if (!(uuid = sid_ucmd_get_foreign_mod_kv(module, ucmd_ctx, "type/dm", KV_NS_DEVMOD, "uuid", NULL, NULL)))
+	if (!(uuid = sid_ucmd_get_foreign_mod_kv(module, ucmd_ctx, "type/dm", KV_NS_DEVMOD, "uuid", NULL, NULL, 0)))
 		return 0;
 
 	return !strncmp(uuid, LVM_DM_UUID_PREFIX, sizeof(LVM_DM_UUID_PREFIX) - 1);

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -1264,13 +1264,14 @@ static int _passes_global_reservation_check(struct sid_ucmd_ctx    *ucmd_ctx,
 	void                  *found;
 	size_t                 value_size;
 	kv_store_value_flags_t kv_store_value_flags;
-	struct kv_key_spec     key_spec = {.op      = KV_OP_SET,
-	                                   .dom     = dom ?: ID_NULL,
-	                                   .ns      = ns,
-	                                   .ns_part = ID_NULL,
-	                                   .id_cat  = ID_NULL,
-	                                   .id      = ID_NULL,
-	                                   .core    = key_core};
+	struct kv_key_spec     key_spec = {.extra_op = NULL,
+	                                   .op       = KV_OP_SET,
+	                                   .dom      = dom ?: ID_NULL,
+	                                   .ns       = ns,
+	                                   .ns_part  = ID_NULL,
+	                                   .id_cat   = ID_NULL,
+	                                   .id       = ID_NULL,
+	                                   .core     = key_core};
 	int                    r        = 1;
 
 	if ((ns != KV_NS_UDEV) && (ns != KV_NS_DEVICE))
@@ -2083,13 +2084,14 @@ static void *_do_sid_ucmd_set_kv(struct module          *mod,
 	kv_vector_t          vvalue[VVALUE_SINGLE_CNT];
 	kv_scalar_t         *svalue;
 	struct kv_update_arg update_arg;
-	struct kv_key_spec   key_spec = {.op      = KV_OP_SET,
-	                                 .dom     = dom ?: ID_NULL,
-	                                 .ns      = ns,
-	                                 .ns_part = _get_ns_part(mod, ucmd_ctx, ns),
-	                                 .id_cat  = ns == KV_NS_DEVMOD ? KV_PREFIX_NS_MODULE_C : ID_NULL,
-	                                 .id      = ns == KV_NS_DEVMOD ? _get_ns_part(mod, ucmd_ctx, KV_NS_MODULE) : ID_NULL,
-	                                 .core    = key_core};
+	struct kv_key_spec   key_spec = {.extra_op = NULL,
+	                                 .op       = KV_OP_SET,
+	                                 .dom      = dom ?: ID_NULL,
+	                                 .ns       = ns,
+	                                 .ns_part  = _get_ns_part(mod, ucmd_ctx, ns),
+	                                 .id_cat   = ns == KV_NS_DEVMOD ? KV_PREFIX_NS_MODULE_C : ID_NULL,
+	                                 .id       = ns == KV_NS_DEVMOD ? _get_ns_part(mod, ucmd_ctx, KV_NS_MODULE) : ID_NULL,
+	                                 .core     = key_core};
 	int                  r;
 	void                *ret = NULL;
 
@@ -2385,13 +2387,14 @@ int _do_sid_ucmd_mod_reserve_kv(struct module              *mod,
 	sid_ucmd_kv_flags_t  flags = unset ? KV_FLAGS_UNSET : KV_MOD_RESERVED;
 	struct kv_update_arg update_arg;
 	int                  is_worker;
-	struct kv_key_spec   key_spec = {.op      = KV_OP_SET,
-	                                 .dom     = dom ?: ID_NULL,
-	                                 .ns      = ns,
-	                                 .ns_part = ID_NULL,
-	                                 .id_cat  = ID_NULL,
-	                                 .id      = ID_NULL,
-	                                 .core    = key_core};
+	struct kv_key_spec   key_spec = {.extra_op = NULL,
+	                                 .op       = KV_OP_SET,
+	                                 .dom      = dom ?: ID_NULL,
+	                                 .ns       = ns,
+	                                 .ns_part  = ID_NULL,
+	                                 .id_cat   = ID_NULL,
+	                                 .id       = ID_NULL,
+	                                 .core     = key_core};
 	int                  r        = -1;
 
 	if (!(key = _compose_key(common->gen_buf, &key_spec)))
@@ -2588,21 +2591,23 @@ static int _handle_dev_for_group(struct module          *mod,
 
 		.abs_delta    = &((struct kv_delta) {0}),
 
-		.cur_key_spec = &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                .dom     = dom ?: ID_NULL,
-	                                                .ns      = group_ns,
-	                                                .ns_part = _get_ns_part(mod, ucmd_ctx, KV_NS_MODULE),
-	                                                .id_cat  = group_cat,
-	                                                .id      = group_id,
-	                                                .core    = KV_KEY_GEN_GROUP_MEMBERS}),
+		.cur_key_spec = &((struct kv_key_spec) {.extra_op = NULL,
+	                                                .op       = KV_OP_SET,
+	                                                .dom      = dom ?: ID_NULL,
+	                                                .ns       = group_ns,
+	                                                .ns_part  = _get_ns_part(mod, ucmd_ctx, KV_NS_MODULE),
+	                                                .id_cat   = group_cat,
+	                                                .id       = group_id,
+	                                                .core     = KV_KEY_GEN_GROUP_MEMBERS}),
 
-		.rel_key_spec = &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                .dom     = ID_NULL,
-	                                                .ns      = KV_NS_DEVICE,
-	                                                .ns_part = dev_id ?: _get_ns_part(mod, ucmd_ctx, KV_NS_DEVICE),
-	                                                .id_cat  = ID_NULL,
-	                                                .id      = ID_NULL,
-	                                                .core    = KV_KEY_GEN_GROUP_IN})};
+		.rel_key_spec = &((struct kv_key_spec) {.extra_op = NULL,
+	                                                .op       = KV_OP_SET,
+	                                                .dom      = ID_NULL,
+	                                                .ns       = KV_NS_DEVICE,
+	                                                .ns_part  = dev_id ?: _get_ns_part(mod, ucmd_ctx, KV_NS_DEVICE),
+	                                                .id_cat   = ID_NULL,
+	                                                .id       = ID_NULL,
+	                                                .core     = KV_KEY_GEN_GROUP_IN})};
 
 	struct kv_update_arg update_arg = {.res     = ucmd_ctx->common->kv_store_res,
 	                                   .owner   = OWNER_CORE,
@@ -2667,13 +2672,14 @@ static int _do_sid_ucmd_group_create(struct module          *mod,
 	kv_vector_t vvalue[VVALUE_HEADER_CNT];
 	int         r                   = -1;
 
-	struct kv_key_spec key_spec     = {.op      = KV_OP_SET,
-	                                   .dom     = dom ?: ID_NULL,
-	                                   .ns      = group_ns,
-	                                   .ns_part = _get_ns_part(mod, ucmd_ctx, group_ns),
-	                                   .id_cat  = group_cat,
-	                                   .id      = group_id,
-	                                   .core    = KV_KEY_GEN_GROUP_MEMBERS};
+	struct kv_key_spec key_spec     = {.extra_op = NULL,
+	                                   .op       = KV_OP_SET,
+	                                   .dom      = dom ?: ID_NULL,
+	                                   .ns       = group_ns,
+	                                   .ns_part  = _get_ns_part(mod, ucmd_ctx, group_ns),
+	                                   .id_cat   = group_cat,
+	                                   .id       = group_id,
+	                                   .core     = KV_KEY_GEN_GROUP_MEMBERS};
 
 	struct kv_update_arg update_arg = {.res      = ucmd_ctx->common->kv_store_res,
 	                                   .owner    = owner,
@@ -2758,21 +2764,23 @@ static int _do_sid_ucmd_group_destroy(struct module          *mod,
 	struct kv_rel_spec rel_spec  = {.delta = &((struct kv_delta) {.op = KV_OP_SET, .flags = DELTA_WITH_DIFF | DELTA_WITH_REL}),
 	                                .abs_delta    = &((struct kv_delta) {0}),
 
-	                                .cur_key_spec = &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                                        .dom     = dom ?: ID_NULL,
-	                                                                        .ns      = group_ns,
-	                                                                        .ns_part = _get_ns_part(mod, ucmd_ctx, group_ns),
-	                                                                        .id_cat  = group_cat,
-	                                                                        .id      = group_id,
-	                                                                        .core    = KV_KEY_GEN_GROUP_MEMBERS}),
+	                                .cur_key_spec = &((struct kv_key_spec) {.extra_op = NULL,
+	                                                                        .op       = KV_OP_SET,
+	                                                                        .dom      = dom ?: ID_NULL,
+	                                                                        .ns       = group_ns,
+	                                                                        .ns_part  = _get_ns_part(mod, ucmd_ctx, group_ns),
+	                                                                        .id_cat   = group_cat,
+	                                                                        .id       = group_id,
+	                                                                        .core     = KV_KEY_GEN_GROUP_MEMBERS}),
 
-	                                .rel_key_spec = &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                                        .dom     = ID_NULL,
-	                                                                        .ns      = 0,
-	                                                                        .ns_part = ID_NULL,
-	                                                                        .id_cat  = ID_NULL,
-	                                                                        .id      = ID_NULL,
-	                                                                        .core    = KV_KEY_GEN_GROUP_IN})};
+	                                .rel_key_spec = &((struct kv_key_spec) {.extra_op = NULL,
+	                                                                        .op       = KV_OP_SET,
+	                                                                        .dom      = ID_NULL,
+	                                                                        .ns       = 0,
+	                                                                        .ns_part  = ID_NULL,
+	                                                                        .id_cat   = ID_NULL,
+	                                                                        .id       = ID_NULL,
+	                                                                        .core     = KV_KEY_GEN_GROUP_IN})};
 
 	struct kv_update_arg update_arg = {.res     = ucmd_ctx->common->kv_store_res,
 	                                   .owner   = OWNER_CORE,
@@ -3371,13 +3379,14 @@ const void *sid_ucmd_part_get_disk_kv(struct module       *mod,
                                       sid_ucmd_kv_flags_t *flags)
 {
 	char               devno_buf[16];
-	struct kv_key_spec key_spec = {.op      = KV_OP_SET,
-	                               .dom     = KV_KEY_DOM_USER,
-	                               .ns      = KV_NS_DEVICE,
-	                               .ns_part = ID_NULL, /* will be calculated later */
-	                               .id_cat  = ID_NULL,
-	                               .id      = ID_NULL,
-	                               .core    = key_core};
+	struct kv_key_spec key_spec = {.extra_op = NULL,
+	                               .op       = KV_OP_SET,
+	                               .dom      = KV_KEY_DOM_USER,
+	                               .ns       = KV_NS_DEVICE,
+	                               .ns_part  = ID_NULL, /* will be calculated later */
+	                               .id_cat   = ID_NULL,
+	                               .id       = ID_NULL,
+	                               .core     = key_core};
 
 	if (!mod || !ucmd_ctx || !key_core || !*key_core || (key_core[0] == KV_PREFIX_KEY_SYS_C[0]))
 		return NULL;
@@ -3396,13 +3405,14 @@ static const char *_devno_to_devid(struct sid_ucmd_ctx *ucmd_ctx, const char *de
 	const char        *key;
 	kv_vector_t       *vvalue;
 	size_t             value_size;
-	struct kv_key_spec key_spec = {.op      = KV_OP_SET,
-	                               .dom     = KV_KEY_DOM_ALIAS,
-	                               .ns      = KV_NS_MODULE,
-	                               .ns_part = _get_ns_part(NULL, ucmd_ctx, KV_NS_MODULE),
-	                               .id_cat  = "devno",
-	                               .id      = devno,
-	                               .core    = KV_KEY_GEN_GROUP_MEMBERS};
+	struct kv_key_spec key_spec = {.extra_op = NULL,
+	                               .op       = KV_OP_SET,
+	                               .dom      = KV_KEY_DOM_ALIAS,
+	                               .ns       = KV_NS_MODULE,
+	                               .ns_part  = _get_ns_part(NULL, ucmd_ctx, KV_NS_MODULE),
+	                               .id_cat   = "devno",
+	                               .id       = devno,
+	                               .core     = KV_KEY_GEN_GROUP_MEMBERS};
 
 	if (!(key = _compose_key(ucmd_ctx->common->gen_buf, &key_spec)))
 		goto out;
@@ -3444,21 +3454,23 @@ static int _refresh_device_disk_hierarchy_from_sysfs(sid_resource_t *cmd_res)
 	                               .abs_delta = &((struct kv_delta) {0}),
 
 	                               .cur_key_spec =
-	                                       &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                               .dom     = ID_NULL,
-	                                                               .ns      = KV_NS_DEVICE,
-	                                                               .ns_part = _get_ns_part(NULL, ucmd_ctx, KV_NS_DEVICE),
-	                                                               .id_cat  = ID_NULL,
-	                                                               .id      = ID_NULL,
-	                                                               .core    = KV_KEY_GEN_GROUP_MEMBERS}),
+	                                       &((struct kv_key_spec) {.extra_op = NULL,
+	                                                               .op       = KV_OP_SET,
+	                                                               .dom      = ID_NULL,
+	                                                               .ns       = KV_NS_DEVICE,
+	                                                               .ns_part  = _get_ns_part(NULL, ucmd_ctx, KV_NS_DEVICE),
+	                                                               .id_cat   = ID_NULL,
+	                                                               .id       = ID_NULL,
+	                                                               .core     = KV_KEY_GEN_GROUP_MEMBERS}),
 
-	                               .rel_key_spec = &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                                       .dom     = ID_NULL,
-	                                                                       .ns      = KV_NS_DEVICE,
-	                                                                       .ns_part = ID_NULL, /* will be calculated later */
-	                                                                       .id_cat  = ID_NULL,
-	                                                                       .id      = ID_NULL,
-	                                                                       .core    = KV_KEY_GEN_GROUP_IN})};
+	                               .rel_key_spec = &((struct kv_key_spec) {.extra_op = NULL,
+	                                                                       .op       = KV_OP_SET,
+	                                                                       .dom      = ID_NULL,
+	                                                                       .ns       = KV_NS_DEVICE,
+	                                                                       .ns_part  = ID_NULL, /* will be calculated later */
+	                                                                       .id_cat   = ID_NULL,
+	                                                                       .id       = ID_NULL,
+	                                                                       .core     = KV_KEY_GEN_GROUP_IN})};
 
 	struct kv_update_arg update_arg = {.res     = ucmd_ctx->common->kv_store_res,
 	                                   .owner   = OWNER_CORE,
@@ -3640,21 +3652,23 @@ static int _refresh_device_partition_hierarchy_from_sysfs(sid_resource_t *cmd_re
 	                               .abs_delta = &((struct kv_delta) {0}),
 
 	                               .cur_key_spec =
-	                                       &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                               .dom     = ID_NULL,
-	                                                               .ns      = KV_NS_DEVICE,
-	                                                               .ns_part = _get_ns_part(NULL, ucmd_ctx, KV_NS_DEVICE),
-	                                                               .id_cat  = ID_NULL,
-	                                                               .id      = ID_NULL,
-	                                                               .core    = KV_KEY_GEN_GROUP_MEMBERS}),
+	                                       &((struct kv_key_spec) {.extra_op = NULL,
+	                                                               .op       = KV_OP_SET,
+	                                                               .dom      = ID_NULL,
+	                                                               .ns       = KV_NS_DEVICE,
+	                                                               .ns_part  = _get_ns_part(NULL, ucmd_ctx, KV_NS_DEVICE),
+	                                                               .id_cat   = ID_NULL,
+	                                                               .id       = ID_NULL,
+	                                                               .core     = KV_KEY_GEN_GROUP_MEMBERS}),
 
-	                               .rel_key_spec = &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                                       .dom     = ID_NULL,
-	                                                                       .ns      = KV_NS_DEVICE,
-	                                                                       .ns_part = ID_NULL, /* will be calculated later */
-	                                                                       .id_cat  = ID_NULL,
-	                                                                       .id      = ID_NULL,
-	                                                                       .core    = KV_KEY_GEN_GROUP_IN})};
+	                               .rel_key_spec = &((struct kv_key_spec) {.extra_op = NULL,
+	                                                                       .op       = KV_OP_SET,
+	                                                                       .dom      = ID_NULL,
+	                                                                       .ns       = KV_NS_DEVICE,
+	                                                                       .ns_part  = ID_NULL, /* will be calculated later */
+	                                                                       .id_cat   = ID_NULL,
+	                                                                       .id       = ID_NULL,
+	                                                                       .core     = KV_KEY_GEN_GROUP_IN})};
 
 	struct kv_update_arg update_arg = {.res     = ucmd_ctx->common->kv_store_res,
 	                                   .owner   = OWNER_CORE,
@@ -5529,13 +5543,14 @@ static int _set_up_kv_store_generation(struct sid_ucmd_common_ctx *ctx)
 	kv_scalar_t *svalue;
 
 	if (!(key = _compose_key(ctx->gen_buf,
-	                         &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                 .dom     = ID_NULL,
-	                                                 .ns      = KV_NS_GLOBAL,
-	                                                 .ns_part = ID_NULL,
-	                                                 .id_cat  = ID_NULL,
-	                                                 .id      = ID_NULL,
-	                                                 .core    = KV_KEY_DB_GENERATION}))))
+	                         &((struct kv_key_spec) {.extra_op = NULL,
+	                                                 .op       = KV_OP_SET,
+	                                                 .dom      = ID_NULL,
+	                                                 .ns       = KV_NS_GLOBAL,
+	                                                 .ns_part  = ID_NULL,
+	                                                 .id_cat   = ID_NULL,
+	                                                 .id       = ID_NULL,
+	                                                 .core     = KV_KEY_DB_GENERATION}))))
 		return -1;
 
 	if ((svalue = kv_store_get_value(ctx->kv_store_res, key, NULL, NULL))) {
@@ -5572,13 +5587,14 @@ static int _set_up_boot_id(struct sid_ucmd_common_ctx *ctx)
 	int          r;
 
 	if (!(key = _compose_key(ctx->gen_buf,
-	                         &((struct kv_key_spec) {.op      = KV_OP_SET,
-	                                                 .dom     = ID_NULL,
-	                                                 .ns      = KV_NS_GLOBAL,
-	                                                 .ns_part = ID_NULL,
-	                                                 .id_cat  = ID_NULL,
-	                                                 .id      = ID_NULL,
-	                                                 .core    = KV_KEY_BOOT_ID}))))
+	                         &((struct kv_key_spec) {.extra_op = NULL,
+	                                                 .op       = KV_OP_SET,
+	                                                 .dom      = ID_NULL,
+	                                                 .ns       = KV_NS_GLOBAL,
+	                                                 .ns_part  = ID_NULL,
+	                                                 .id_cat   = ID_NULL,
+	                                                 .id       = ID_NULL,
+	                                                 .core     = KV_KEY_BOOT_ID}))))
 		return -1;
 
 	if ((svalue = kv_store_get_value(ctx->kv_store_res, key, NULL, NULL)))

--- a/tests/test_db_sync.c
+++ b/tests/test_db_sync.c
@@ -104,13 +104,14 @@ int _do_build_buffers(sid_resource_t *cmd_res)
 	return fd;
 }
 
-struct kv_key_spec base_spec = {.op      = KV_OP_SET,
-                                .dom     = KV_KEY_DOM_USER,
-                                .ns      = KV_NS_GLOBAL,
-                                .ns_part = ID_NULL,
-                                .id_cat  = ID_NULL,
-                                .id      = ID_NULL,
-                                .core    = ID_NULL};
+struct kv_key_spec base_spec = {.extra_op = NULL,
+                                .op       = KV_OP_SET,
+                                .dom      = KV_KEY_DOM_USER,
+                                .ns       = KV_NS_GLOBAL,
+                                .ns_part  = ID_NULL,
+                                .id_cat   = ID_NULL,
+                                .id       = ID_NULL,
+                                .core     = ID_NULL};
 
 static void _check_missing_kv(struct sid_ucmd_ctx *ucmd_ctx, const char *core)
 {


### PR DESCRIPTION
The new kv_store_set_value_with_archive automatically creates an archive
of the value currently bound to a 'key' and bounds it to an 'archive_key'
before an update is done for the record under the 'key'.