### PR TITLE
Misc cleanups

### DIFF
--- a/src/iface/service-link.c
+++ b/src/iface/service-link.c
@@ -70,16 +70,14 @@ void service_link_destroy(struct service_link *sl)
 	free(sl);
 }
 
-int service_link_add_notification(struct service_link *sl, service_link_notification_t notification)
+void service_link_add_notification(struct service_link *sl, service_link_notification_t notification)
 {
 	sl->notification |= notification;
-	return 0;
 }
 
-int service_link_remove_notification(struct service_link *sl, service_link_notification_t notification)
+void service_link_remove_notification(struct service_link *sl, service_link_notification_t notification)
 {
 	sl->notification &= ~notification;
-	return 0;
 }
 
 struct service_link_group *service_link_group_create(const char *name)
@@ -115,12 +113,10 @@ void service_link_group_destroy_with_members(struct service_link_group *slg)
 	free(slg);
 }
 
-int service_link_group_add_member(struct service_link_group *slg, struct service_link *sl)
+void service_link_group_add_member(struct service_link_group *slg, struct service_link *sl)
 {
 	list_add(&slg->members, &sl->list);
 	sl->group = slg;
-
-	return 0;
 }
 
 int service_link_group_remove_member(struct service_link_group *slg, struct service_link *sl)
@@ -150,7 +146,7 @@ static const char *_get_arg_value(const char *str, const char *key_eq, size_t *s
 		if (!strncmp(key_eq, str, strlen(key_eq))) {
 			/* get the value and its size */
 			str   += strlen(key_eq);
-			*size = line_end - str;
+			*size  = line_end - str;
 			return str;
 		}
 	}

--- a/src/include/iface/service-link.h
+++ b/src/include/iface/service-link.h
@@ -82,15 +82,15 @@ struct service_link_group;
 struct service_link *service_link_create(service_link_type_t type, const char *name);
 void                 service_link_destroy(struct service_link *sl);
 
-int service_link_add_notification(struct service_link *sl, service_link_notification_t notification);
-int service_link_remove_notification(struct service_link *sl, service_link_notification_t notification);
+void service_link_add_notification(struct service_link *sl, service_link_notification_t notification);
+void service_link_remove_notification(struct service_link *sl, service_link_notification_t notification);
 
 struct service_link_group *service_link_group_create(const char *name);
 void                       service_link_group_destroy(struct service_link_group *slg);
 void                       service_link_group_destroy_with_members(struct service_link_group *slg);
 
-int service_link_group_add_member(struct service_link_group *slg, struct service_link *sl);
-int service_link_group_remove_member(struct service_link_group *slg, struct service_link *sl);
+void service_link_group_add_member(struct service_link_group *slg, struct service_link *sl);
+int  service_link_group_remove_member(struct service_link_group *slg, struct service_link *sl);
 
 /*
  * Send service notification.

--- a/src/modules/ucmd/type/dm/dm.c
+++ b/src/modules/ucmd/type/dm/dm.c
@@ -170,12 +170,18 @@ static int _dm_ident(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
 	log_debug(DM_ID, "ident");
 
 	snprintf(path, sizeof(path), "%s%s/dm/uuid", SYSTEM_SYSFS_PATH, sid_ucmd_event_get_dev_path(ucmd_ctx));
-	sid_util_sysfs_get_value(path, uuid, sizeof(uuid));
+	if (sid_util_sysfs_get_value(path, uuid, sizeof(uuid)) < 0) {
+		log_error(DM_ID, "Failed to get DM uuid.");
+		return -1;
+	}
 	sid_ucmd_dev_add_alias(module, ucmd_ctx, "uuid", uuid);
 	sid_ucmd_set_kv(module, ucmd_ctx, KV_NS_DEVMOD, "uuid", uuid, strlen(uuid) + 1, KV_SYNC | KV_SUB_RD);
 
 	snprintf(path, sizeof(path), "%s%s/dm/name", SYSTEM_SYSFS_PATH, sid_ucmd_event_get_dev_path(ucmd_ctx));
-	sid_util_sysfs_get_value(path, name, sizeof(name));
+	if (sid_util_sysfs_get_value(path, name, sizeof(name)) < 0) {
+		log_error(DM_ID, "Failed to get DM name.");
+		return -1;
+	}
 	sid_ucmd_dev_add_alias(module, ucmd_ctx, "name", name);
 	sid_ucmd_set_kv(module, ucmd_ctx, KV_NS_DEVMOD, "name", name, strlen(name) + 1, KV_SYNC | KV_SUB_RD);
 

--- a/src/resource/resource.c
+++ b/src/resource/resource.c
@@ -194,11 +194,8 @@ static int _create_service_link_group(sid_resource_t *res, sid_resource_service_
 			goto out;
 		}
 
-		if ((r = service_link_add_notification(sl, def->notification)) < 0)
-			goto out;
-
-		if ((r = service_link_group_add_member(slg, sl)) < 0)
-			goto out;
+		service_link_add_notification(sl, def->notification);
+		service_link_group_add_member(slg, sl);
 	}
 
 	res->slg = slg;

--- a/src/resource/resource.c
+++ b/src/resource/resource.c
@@ -264,6 +264,8 @@ sid_resource_t *sid_resource_create(sid_resource_t                 *parent_res,
 		goto fail;
 
 	res->id = id;
+	list_init(&res->children);
+	list_init(&res->event_sources);
 
 	/*
 	 * Take temporary reference!
@@ -280,8 +282,7 @@ sid_resource_t *sid_resource_create(sid_resource_t                 *parent_res,
 	if (_create_service_link_group(res, service_link_defs) < 0)
 		goto fail;
 
-	res->flags = flags;
-	list_init(&res->children);
+	res->flags                    = flags;
 	res->type                     = type;
 	res->prio                     = prio;
 	res->event_loop.sd_event_loop = NULL;
@@ -290,8 +291,6 @@ sid_resource_t *sid_resource_create(sid_resource_t                 *parent_res,
 
 	if (type->with_event_loop && sd_event_new(&res->event_loop.sd_event_loop) < 0)
 		goto fail;
-
-	list_init(&res->event_sources);
 
 	_add_res_to_parent_res(res, parent_res);
 

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -4594,12 +4594,12 @@ static int _check_msg(sid_resource_t *res, struct sid_msg *msg)
 {
 	struct sid_msg_header header;
 
-	memcpy(&header, msg->header, sizeof(header));
-
 	if (msg->size < sizeof(struct sid_msg_header)) {
 		log_error(ID(res), "Incorrect message header size.");
 		return -1;
 	}
+
+	memcpy(&header, msg->header, sizeof(header));
 
 	/* Sanitize command number - map all out of range command numbers to CMD_UNKNOWN. */
 	switch (msg->cat) {
@@ -4638,10 +4638,10 @@ static int _create_command_resource(sid_resource_t *parent_res, struct sid_msg *
 {
 	struct sid_msg_header header;
 
-	memcpy(&header, msg->header, sizeof(header));
-
 	if (_check_msg(parent_res, msg) < 0)
 		return -1;
+
+	memcpy(&header, msg->header, sizeof(header));
 
 	if (!sid_resource_create(parent_res,
 	                         &sid_resource_type_ubridge_command,

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3667,12 +3667,13 @@ static int _refresh_device_disk_hierarchy_from_sysfs(sid_resource_t *cmd_res)
 	 *   +VVALUE_HEADER_CNT to include record header
 	 *   -2 to subtract "." and ".." directory which we're not interested in
 	 */
-	if (!(vec_buf = sid_buffer_create(
-		      &((struct sid_buffer_spec) {.backend = SID_BUFFER_BACKEND_MALLOC,
-	                                          .type    = SID_BUFFER_TYPE_VECTOR,
-	                                          .mode    = SID_BUFFER_MODE_PLAIN}),
-		      &((struct sid_buffer_init) {.size = count + VVALUE_HEADER_CNT - 2, .alloc_step = 1, .limit = 0}),
-		      &r))) {
+	if (!(vec_buf = sid_buffer_create(&((struct sid_buffer_spec) {.backend = SID_BUFFER_BACKEND_MALLOC,
+	                                                              .type    = SID_BUFFER_TYPE_VECTOR,
+	                                                              .mode    = SID_BUFFER_MODE_PLAIN}),
+		                          &((struct sid_buffer_init) {.size = VVALUE_HEADER_CNT + (count >= 2 ? count - 2 : 0),
+	                                                              .alloc_step = 1,
+	                                                              .limit      = 0}),
+		                          &r))) {
 		log_error_errno(ID(cmd_res),
 		                r,
 		                "Failed to create buffer to record hierarchy for device " CMD_DEV_NAME_NUM_FMT,

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -4737,6 +4737,7 @@ fail:
 			sid_buffer_destroy(conn->buf);
 		free(conn);
 	}
+	close(data_spec->ext.socket.fd_pass);
 	return -1;
 }
 

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3748,8 +3748,10 @@ static int _refresh_device_disk_hierarchy_from_sysfs(sid_resource_t *cmd_res)
 				}
 
 				s = _compose_key_prefix(NULL, rel_spec.rel_key_spec);
-				if (!s || ((r = sid_buffer_add(vec_buf, (void *) s, strlen(s) + 1, NULL, NULL)) < 0))
+				if (!s || ((r = sid_buffer_add(vec_buf, (void *) s, strlen(s) + 1, NULL, NULL)) < 0)) {
+					_destroy_key(NULL, s);
 					goto out;
+				}
 			}
 next:
 			free(dirent[i]);

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -3802,8 +3802,8 @@ static int _refresh_device_partition_hierarchy_from_sysfs(sid_resource_t *cmd_re
 	kv_vector_t          vvalue[VVALUE_SINGLE_CNT];
 	char                 devno_buf[16];
 	char                 devid_buf[UTIL_UUID_STR_SIZE];
-	const char          *s;
-	char                *key;
+	const char          *s   = NULL;
+	char                *key = NULL;
 	util_mem_t           mem;
 	int                  r      = -1;
 
@@ -3876,10 +3876,10 @@ static int _refresh_device_partition_hierarchy_from_sysfs(sid_resource_t *cmd_re
 	 */
 	_kv_delta_set(key, vvalue, VVALUE_SINGLE_CNT, &update_arg, true);
 
-	_destroy_key(NULL, key);
-	_destroy_key(NULL, s);
 	r = 0;
 out:
+	_destroy_key(NULL, key);
+	_destroy_key(NULL, s);
 	return r;
 }
 

--- a/tests/test_notify.c
+++ b/tests/test_notify.c
@@ -28,7 +28,7 @@ static void test_notify_ready(void **state)
 	struct service_link *sl = service_link_create(SERVICE_TYPE_SYSTEMD, "systemd");
 
 	assert_non_null(sl);
-	assert_int_equal(service_link_add_notification(sl, SERVICE_NOTIFICATION_READY), 0);
+	service_link_add_notification(sl, SERVICE_NOTIFICATION_READY);
 	will_return(__wrap_sd_notify, "READY=1\n");
 	assert_int_equal(service_link_notify(sl, SERVICE_NOTIFICATION_READY, NULL), 0);
 	service_link_destroy(sl);
@@ -39,8 +39,8 @@ static void test_notify_ready_reloading(void **state)
 	struct service_link *sl = service_link_create(SERVICE_TYPE_SYSTEMD, "systemd");
 
 	assert_non_null(sl);
-	assert_int_equal(service_link_add_notification(sl, SERVICE_NOTIFICATION_READY), 0);
-	assert_int_equal(service_link_add_notification(sl, SERVICE_NOTIFICATION_RELOADING), 0);
+	service_link_add_notification(sl, SERVICE_NOTIFICATION_READY);
+	service_link_add_notification(sl, SERVICE_NOTIFICATION_RELOADING);
 	will_return(__wrap_sd_notify, "READY=1\nRELOADING=1\n");
 	assert_int_equal(service_link_notify(sl, SERVICE_NOTIFICATION_READY | SERVICE_NOTIFICATION_RELOADING, NULL), 0);
 	service_link_destroy(sl);
@@ -51,7 +51,7 @@ static void test_notify_blank(void **state)
 	struct service_link *sl = service_link_create(SERVICE_TYPE_SYSTEMD, "systemd");
 
 	assert_non_null(sl);
-	assert_int_equal(service_link_add_notification(sl, SERVICE_NOTIFICATION_STATUS), 0);
+	service_link_add_notification(sl, SERVICE_NOTIFICATION_STATUS);
 	will_return(__wrap_sd_notify, "");
 	assert_int_equal(service_link_notify(sl, SERVICE_NOTIFICATION_STATUS, NULL), 0);
 	service_link_destroy(sl);
@@ -62,7 +62,7 @@ static void test_notify_errno(void **state)
 	struct service_link *sl = service_link_create(SERVICE_TYPE_SYSTEMD, "systemd");
 
 	assert_non_null(sl);
-	assert_int_equal(service_link_add_notification(sl, SERVICE_NOTIFICATION_ERRNO), 0);
+	service_link_add_notification(sl, SERVICE_NOTIFICATION_ERRNO);
 	will_return(__wrap_sd_notify, "ERRNO=2\n");
 	assert_int_equal(service_link_notify(sl, SERVICE_NOTIFICATION_ERRNO, "ERRNO=%d\n", 2), 0);
 	service_link_destroy(sl);
@@ -73,8 +73,8 @@ static void test_notify_errno_status(void **state)
 	struct service_link *sl = service_link_create(SERVICE_TYPE_SYSTEMD, "systemd");
 
 	assert_non_null(sl);
-	assert_int_equal(service_link_add_notification(sl, SERVICE_NOTIFICATION_ERRNO), 0);
-	assert_int_equal(service_link_add_notification(sl, SERVICE_NOTIFICATION_STATUS), 0);
+	service_link_add_notification(sl, SERVICE_NOTIFICATION_ERRNO);
+	service_link_add_notification(sl, SERVICE_NOTIFICATION_STATUS);
 	will_return(__wrap_sd_notify, "STATUS=testing\nERRNO=2\n");
 	assert_int_equal(
 		service_link_notify(sl, SERVICE_NOTIFICATION_ERRNO | SERVICE_NOTIFICATION_STATUS, "ERRNO=%d\nSTATUS=testing", 2),


### PR DESCRIPTION
I've gotten distracted with other things, so I haven't made much progress on the remove work yet, but here are some fixes that I've accumulated while looking through the code to understand what needs to be done.  I'm not quite sure if the final commit is the correct solution (erroring out instead of just skipping the failed sysfs attribute and going on). But the most likely cause of this seems to be that the sysfs device has disappeared. Right now this happens during remove events, but even when those have a different call path, the sysfs device could still get removed while we are processing an earlier uevent. in this case, I don't see much point in continuing to update the database for the device. But if you'd rather the code skip adding that attribute and continue with the function, I can change it.