### PR TITLE
More bugfixes and remove infrastructure

### DIFF
--- a/src/include/resource/ucmd-module.h
+++ b/src/include/resource/ucmd-module.h
@@ -43,6 +43,8 @@ extern "C" {
 #define SID_UCMD_MOD_FN_NAME_SCAN_POST_CURRENT "sid_ucmd_scan_post_current"
 #define SID_UCMD_MOD_FN_NAME_SCAN_POST_NEXT    "sid_ucmd_scan_post_next"
 
+#define SID_UCMD_MOD_FN_NAME_SCAN_REMOVE       "sid_ucmd_scan_remove"
+
 #define SID_UCMD_MOD_FN_NAME_ERROR             "sid_ucmd_error"
 
 struct sid_ucmd_common_ctx;
@@ -62,6 +64,7 @@ struct sid_ucmd_mod_fns {
 	sid_ucmd_fn_t *scan_post_next;
 	sid_ucmd_fn_t *trigger_action_current;
 	sid_ucmd_fn_t *trigger_action_next;
+	sid_ucmd_fn_t *scan_remove;
 	sid_ucmd_fn_t *error;
 } __packed;
 
@@ -123,6 +126,7 @@ struct sid_ucmd_mod_fns {
 #define SID_UCMD_SCAN_POST_NEXT(fn)         SID_UCMD_FN(scan_post_next, _SID_UCMD_FN_CHECK_TYPE(fn))
 #define SID_UCMD_TRIGGER_ACTION_CURRENT(fn) SID_UCMD_FN(trigger_action_current, _SID_UCMD_FN_CHECK_TYPE(fn))
 #define SID_UCMD_TRIGGER_ACTION_NEXT(fn)    SID_UCMD_FN(trigger_action_next, _SID_UCMD_FN_CHECK_TYPE(fn))
+#define SID_UCMD_SCAN_REMOVE(fn)            SID_UCMD_FN(scan_emove, _SID_UCMD_FN_CHECK_TYPE(fn))
 #define SID_UCMD_ERROR(fn)                  SID_UCMD_FN(error, _SID_UCMD_FN_CHECK_TYPE(fn))
 
 /*

--- a/src/modules/ucmd/block/blkid/blkid.c
+++ b/src/modules/ucmd/block/blkid/blkid.c
@@ -297,6 +297,13 @@ out:
 }
 SID_UCMD_SCAN_NEXT(_blkid_scan_next)
 
+static int _blkid_scan_remove(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
+{
+	log_debug(MID, "scan-remove");
+	return 0;
+}
+SID_UCMD_SCAN_REMOVE(_blkid_scan_remove)
+
 static int _blkid_error(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
 {
 	log_debug(MID, "error");

--- a/src/modules/ucmd/block/dm_mpath/dm_mpath.c
+++ b/src/modules/ucmd/block/dm_mpath/dm_mpath.c
@@ -171,6 +171,13 @@ static int _dm_mpath_scan_next(struct module *module, struct sid_ucmd_ctx *ucmd_
 }
 SID_UCMD_SCAN_NEXT(_dm_mpath_scan_next)
 
+static int _dm_mpath_scan_remove(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
+{
+	log_debug(MID, "scan-remove");
+	return 0;
+}
+SID_UCMD_SCAN_REMOVE(_dm_mpath_scan_remove)
+
 static int _dm_mpath_error(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
 {
 	log_debug(MID, "error");

--- a/src/modules/ucmd/block/dummy_block/dummy_block.c
+++ b/src/modules/ucmd/block/dummy_block/dummy_block.c
@@ -101,6 +101,13 @@ static int _dummy_block_trigger_action_next(struct module *module, struct sid_uc
 }
 SID_UCMD_TRIGGER_ACTION_NEXT(_dummy_block_trigger_action_next)
 
+static int _dummy_block_scan_remove(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
+{
+	log_debug(MID, "scan-remove");
+	return 0;
+}
+SID_UCMD_SCAN_REMOVE(_dummy_block_scan_remove)
+
 static int _dummy_block_error(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
 {
 	log_debug(MID, "error");

--- a/src/modules/ucmd/type/dm/dm.c
+++ b/src/modules/ucmd/type/dm/dm.c
@@ -68,6 +68,10 @@ static struct module_symbol_params dm_submod_symbol_params[] = {
 		SID_UCMD_MOD_FN_NAME_SCAN_POST_NEXT,
 		MODULE_SYMBOL_INDIRECT,
 	},
+	{
+		SID_UCMD_MOD_FN_NAME_SCAN_REMOVE,
+		MODULE_SYMBOL_INDIRECT,
+	},
 	NULL_MODULE_SYMBOL_PARAMS,
 };
 
@@ -79,6 +83,7 @@ struct dm_submod_fns {
 	sid_ucmd_fn_t *scan_next;
 	sid_ucmd_fn_t *scan_post_current;
 	sid_ucmd_fn_t *scan_post_next;
+	sid_ucmd_fn_t *scan_remove;
 } __packed;
 
 struct dm_mod_ctx {
@@ -355,6 +360,26 @@ static int _dm_scan_post_next(struct module *module, struct sid_ucmd_ctx *ucmd_c
 	return 0;
 }
 SID_UCMD_SCAN_POST_NEXT(_dm_scan_post_next)
+
+static int _dm_scan_remove(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
+{
+	struct dm_mod_ctx    *dm_mod;
+	struct dm_submod_fns *submod_fns;
+
+	log_debug(DM_ID, "scan-remove");
+
+	dm_mod = module_get_data(module);
+
+	if (!dm_mod->submod_res_current)
+		return 0;
+
+	module_registry_get_module_symbols(dm_mod->submod_res_current, (const void ***) &submod_fns);
+	if (submod_fns && submod_fns->scan_remove)
+		(void) submod_fns->scan_remove(sid_resource_get_data(dm_mod->submod_res_current), ucmd_ctx);
+
+	return 0;
+}
+SID_UCMD_SCAN_REMOVE(_dm_scan_remove)
 
 static int _dm_error(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
 {

--- a/src/modules/ucmd/type/dm/lvm/lvm.c
+++ b/src/modules/ucmd/type/dm/lvm/lvm.c
@@ -103,3 +103,10 @@ static int _lvm_scan_post_next(struct module *module, struct sid_ucmd_ctx *ucmd_
 	return 0;
 }
 SID_UCMD_SCAN_POST_NEXT(_lvm_scan_post_next)
+
+static int _lvm_scan_remove(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
+{
+	log_debug(LVM_ID, "scan-remove");
+	return 0;
+}
+SID_UCMD_SCAN_REMOVE(_lvm_scan_remove)

--- a/src/modules/ucmd/type/dummy_type/dummy_type.c
+++ b/src/modules/ucmd/type/dummy_type/dummy_type.c
@@ -101,6 +101,13 @@ static int _dummy_type_trigger_action_next(struct module *module, struct sid_ucm
 }
 SID_UCMD_TRIGGER_ACTION_NEXT(_dummy_type_trigger_action_next)
 
+static int _dummy_type_scan_remove(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
+{
+	log_debug(MID, "scan-remove");
+	return 0;
+}
+SID_UCMD_SCAN_REMOVE(_dummy_type_scan_remove)
+
 static int _dummy_type_error(struct module *module, struct sid_ucmd_ctx *ucmd_ctx)
 {
 	log_debug(MID, "error");

--- a/src/resource/ubridge.c
+++ b/src/resource/ubridge.c
@@ -4204,6 +4204,8 @@ static int _cmd_exec_scan_ident(struct cmd_exec_arg *exec_arg)
 	const struct sid_ucmd_mod_fns *mod_fns;
 	const char                    *mod_name;
 
+	_execute_block_modules(exec_arg, CMD_SCAN_PHASE_A_IDENT);
+
 	if (!(mod_name = _do_sid_ucmd_get_kv(NULL, ucmd_ctx, NULL, KV_NS_DEVICE, KV_KEY_DEV_MOD, NULL, NULL, 0))) {
 		if (!(mod_name = _lookup_mod_name(exec_arg->cmd_res,
 		                                  ucmd_ctx->req_env.dev.udev.major,
@@ -4231,8 +4233,6 @@ static int _cmd_exec_scan_ident(struct cmd_exec_arg *exec_arg)
 
 	if (!(exec_arg->type_mod_res_current = module_registry_get_module(exec_arg->type_mod_registry_res, mod_name)))
 		log_debug(ID(exec_arg->cmd_res), "Module %s not loaded.", mod_name);
-
-	_execute_block_modules(exec_arg, CMD_SCAN_PHASE_A_IDENT);
 
 	if (!exec_arg->type_mod_res_current)
 		return 0;


### PR DESCRIPTION
I still keep having other things on my plate that are keeping me from being able to finish up the remove work. Instead, I'll just send you what I currently have, so you can see the direction I'm heading. I've split out the remove work from the regular scan work, although it still uses the "usid scan" command, since there is a lot of code overlap with regular scans. It currently doesn't do anything special on removes. That's what I'm working on next. Also, here are fixes for two bugs that were keeping resyncing the device hierarchy from working on removes.